### PR TITLE
Refactor RecipeInstructions and associated functions

### DIFF
--- a/app.py
+++ b/app.py
@@ -141,7 +141,7 @@ def get_book_recipes(authed_user_id, book_id, user_id):
 def patch_user_recipe(authed_user_id, recipe_id):
     """Facilitate editing of recipe and records associated to book"""
     recipe = RecipeServices.process_edit(user_id=authed_user_id,
-                                         data=request.json, recipe_id=recipe_id)
+                                         data=request.json, recipe_id=int(recipe_id))
     return jsonify(recipe), 200
 
 

--- a/app.py
+++ b/app.py
@@ -444,18 +444,21 @@ def setup_app_context():
 if __name__ == '__main__':
     socketio.run(app, debug=True)
 
+# replace existing instructions
+# !!!!!!!!!!
+# ('edit data:', {'created_by_id': 1, 'name': None, 'ingredients': None, 'instructions': [{'oldId': 3, 'newId': 4}], 'notes': None})
+# !!!!!!!!!!
+# !!!!!!!!!!
+# ('instructions:', [{'oldId': 3, 'newId': 4}])
+# !!!!!!!!!!
+# !!!!!!!!!!
+# ('query_recipe_instructions', 14, 4)
+# !!!!!!!!!!
 
+# add instruction 
 # !!!!!!!!!!
-# ('edit data:', {'created_by_id': 1, 'name': None, 'ingredients': None, 'instructions': [{'oldId': None, 'newId': 3}], 'notes': None})
-# !!!!!!!!!!
-# !!!!!!!!!!
-# ('instructions:', [{'oldId': None, 'newId': 3}])
-# !!!!!!!!!!
-
-
-# !!!!!!!!!!
-# ('edit data:', {'created_by_id': 1, 'name': None, 'ingredients': None, 'instructions': [{'oldId': None, 'newId': 1}, {'oldId': None, 'newId': 2}], 'notes': None})
+# ('edit data:', {'created_by_id': 1, 'name': None, 'ingredients': None,'instructions': [{'oldId': None, 'newId': 2}], 'notes': None})
 # !!!!!!!!!!
 # !!!!!!!!!!
-# ('instructions:', [{'oldId': None, 'newId': 1}, {'oldId': None, 'newId': 2}])
+# ('instructions:', [{'oldId': None, 'newId': 2}])
 # !!!!!!!!!!

--- a/app.py
+++ b/app.py
@@ -285,9 +285,16 @@ def get_book_instructions(authed_user_id, book_id, user_id):
 
 
 @app.post("/test")
-def test_function(authed_id):
+@verify_jwt_identity
+@route_error_handler
+def test_function(authed_user_id):
+    recipient = request.json["recipient"]
+    recipe_id = request.json["recipe_id"]
 
-    RecipeServices.share_recipe()
+    RecipeServices.share_recipe(
+        auth_id=authed_user_id, recipient=recipient, recipe_id=recipe_id)
+
+    return {"message":"success!"}
 
 ################################################################################
 

--- a/app.py
+++ b/app.py
@@ -353,7 +353,7 @@ def share_book(data):
                 books = BookServices.fetch_user_books(
                     user_id=response["recipient_id"])
                 emit('user_shared_book', {
-                     "message": message, "books": books}, room=recipient_id)
+                     "message": message, "books": books, "payload": response.get("payload")}, room=recipient_id)
                 return
             # else:
                 # Future logic to que up message for offline recipient
@@ -429,14 +429,3 @@ def setup_app_context():
 if __name__ == '__main__':
     socketio.run(app, debug=True)
 
-
-{'message': 'Recipe successfully shared!', 'code': 200, 
- 'payload': {'id': 6, 'book_type': 'shared_inbox',
-  'title': 'Shared Recipes', 'description': 'Inbox: Recipes shared by others', 'book_role': 'owner'}, 
-  'recipient_id': 6}
-
-
-{'message': 'Recipe successfully shared!', 'code': 200, 
- 'payload': {'id': 15, 'book_type': 'shared_inbox',
-'title': 'Shared Recipes', 'description': 'Inbox: Recipes shared by others', 'book_role': 'owner'}, 
-'recipient_id': 7}

--- a/app.py
+++ b/app.py
@@ -291,10 +291,10 @@ def test_function(authed_user_id):
     recipient = request.json["recipient"]
     recipe_id = request.json["recipe_id"]
 
-    RecipeServices.share_recipe(
+    res = RecipeServices.process_recipe_share(
         auth_id=authed_user_id, recipient=recipient, recipe_id=recipe_id)
 
-    return {"message":"success!"}
+    return jsonify(res)
 
 ################################################################################
 

--- a/app.py
+++ b/app.py
@@ -396,7 +396,7 @@ def share_recipe(data):
 
         if recipient_id:
             message = f"{sender} has shared '{recipe}'recipe with you!"
-            emit('user_shared_recipe', {
+            emit('user_shared_recipe', {"payload":response.get("payload"),
                  "message": message, "recipe": response["recipe"]}, room=recipient_id)
             return
         # else:

--- a/app.py
+++ b/app.py
@@ -25,11 +25,6 @@ import logging
 import sys
 
 
-# Execute if app doesn't auto update code
-# flask --app app.py --debug run
-# Execute to allow mobile connection
-# flask run --host=0.0.0.0
-
 app = Flask(__name__)
 set_environment_config(app)
 configure_cors(app)
@@ -168,16 +163,6 @@ def delete_shared_recipe(authed_user_id, book_id, recipe_id):
     return jsonify(response), 200 
 
 
-# @app.post("/share_recipes/<recipe_id>")
-# @verify_jwt_identity
-# @route_error_handler
-# def post_share_recipe(recipe_id):
-#     """Facilitate user and recipe data to share recipe with recipient"""
-#     auth_id = get_jwt_identity()
-    # message = RecipeServices.share_recipe(
-    #     auth_id=auth_id, recipient=request.json["recipient"], recipe_id=recipe_id)
-#     return jsonify(message), 200
-
 
 ########### BOOKS ###########
 
@@ -231,14 +216,6 @@ def add_option_association(authed_user_id, book_id, component, option_id, user_i
     return jsonify(response)
 
 
-# @app.get("/ingredients/<ingredient>")
-# @jwt_required()
-# @route_error_handler
-# def get_ingredients(ingredient):
-#     """Facilitates retrieval of ALL options of ingredient components"""
-#     ingredients = IngredientServices.fetch_components_options(ingredient)
-#     return jsonify(ingredients)
-
 
 @app.get("/users/<user_id>/ingredients/components")
 @verify_jwt_identity
@@ -256,17 +233,6 @@ def get_book_ingredient_components(authed_user_id, book_id, user_id):
     return IngredientServices.fetch_book_components_options(book_id=book_id)
 
 
-@app.post("/ingredients/<ingredient>")
-# should identity be checked here?
-# def add_ingredient(ingredient):
-#     """Facilitates creation of ingredient"""
-#     value = request.json
-#     try:
-#         ingredient = IngredientServices.add_ingredient(
-#             option=ingredient, value=value)
-#         return jsonify(ingredient)
-#     except IntegrityError as e:
-#         return jsonify({"error": f"add_ingredient error{e}"}), 400
 ########### INSTRUCTIONS ###########
 @app.post("/users/<user_id>/books/<book_id>/instructions")
 @verify_jwt_identity

--- a/app.py
+++ b/app.py
@@ -154,14 +154,15 @@ def delete_recipe(authed_user_id, user_id, book_id, recipe_id):
         auth_id=authed_user_id, recipe_id=recipe_id, data=request.json)
     return jsonify(response), 200
 
+
 @app.delete("/books/<book_id>/share_recipes/<recipe_id>")
 @verify_jwt_identity
 @route_error_handler
 def delete_shared_recipe(authed_user_id, book_id, recipe_id):
     """Facilitates deletion of association record linking shared recipe to recipient"""
-    response = RecipeServices.remove_shared_recipe(authed_id=authed_user_id, recipe_id=recipe_id, book_id=book_id)
-    return jsonify(response), 200 
-
+    response = RecipeServices.remove_shared_recipe(
+        authed_id=authed_user_id, recipe_id=recipe_id, book_id=book_id)
+    return jsonify(response), 200
 
 
 ########### BOOKS ###########
@@ -171,7 +172,8 @@ def delete_shared_recipe(authed_user_id, book_id, recipe_id):
 @route_error_handler
 def add_book(authed_user_id, user_id):
     """Facilitates creation of book"""
-    book_data = BookServices.process_new_book(request=request, user_id=authed_user_id)
+    book_data = BookServices.process_new_book(
+        request=request, user_id=authed_user_id)
     return jsonify(book_data), 200
 
 
@@ -214,7 +216,6 @@ def add_option_association(authed_user_id, book_id, component, option_id, user_i
     response = IngredientServices.create_option_association(
         component=component, book_id=book_id, option_id=option_id)
     return jsonify(response)
-
 
 
 @app.get("/users/<user_id>/ingredients/components")
@@ -317,7 +318,7 @@ def handle_connect(auth):
 def share_book(data):
     """Facilitates book sharing request and response"""
     user_id = check_auth_users(user_id=authorized_user.get(request.sid))
-    
+
     if not user_id:
         emit('error_sharing_book', {'data': 'Unauthorized'})
         return
@@ -330,15 +331,15 @@ def share_book(data):
     if not all([recipient, book_id, title]):
         emit('error sharing book', {'data': 'Invalid request missing data'})
         return
-    
+
     try:
         response = BookServices.process_shared_book(
             user_id=int(user_id), recipient=recipient, book_id=book_id)
-        
+
         if response["code"] in (422, 409, 404):
             emit('error_sharing_book', {'data': response["message"]})
             return
-        
+
         if response["code"] == 200:
             # SENDER
             sender_id = connected_users.get("user_id")
@@ -355,12 +356,13 @@ def share_book(data):
                      "message": message, "books": books}, room=recipient_id)
                 return
             # else:
-                # Future logic to que up message for offline recipient       
+                # Future logic to que up message for offline recipient
     except Exception as e:
+        db.session.rollback()
         emit('error_sharing_book', {'data': 'Something went wrong'})
         app.logger.error(f"socketio - share_book: {e}")
         return
-    
+
 
 @socketio.on('share_recipe')
 def share_recipe(data):
@@ -375,12 +377,12 @@ def share_recipe(data):
     recipient = data.get("recipient")
 
     if not all([recipe_id, sender, recipe, recipient]):
-            emit('error_sharing_recipe', {'data':'Invalid request missing data'})
-            return
+        emit('error_sharing_recipe', {'data': 'Invalid request missing data'})
+        return
     try:
         response = RecipeServices.share_recipe(
             auth_id=user_id, recipient=recipient, recipe_id=recipe_id)
-        
+
         if response["code"] in (400, 403, 404, 409):
             emit('error_sharing_recipe', {'data': response["message"]})
             return
@@ -389,16 +391,18 @@ def share_recipe(data):
             sender_id = connected_users.get("user_id")
             emit('recipe_shared', {
                  "message": response["message"]}, room=sender_id)
-        #Check if recipient is connected
+        # Check if recipient is connected
         recipient_id = connected_users.get(response["recipient_id"])
-        
+
         if recipient_id:
             message = f"{sender} has shared '{recipe}'recipe with you!"
-            emit('user_shared_recipe', {"message": message, "recipe": response["recipe"]}, room=recipient_id)
+            emit('user_shared_recipe', {
+                 "message": message, "recipe": response["recipe"]}, room=recipient_id)
             return
         # else:
             # Future logic to que up message for offline recipient
     except Exception as e:
+        db.session.rollback()
         emit('error_sharing_recipe', {'data': 'Something went wrong'})
         app.logger.error(f"socketio - share_recipe: {e}")
         return

--- a/app.py
+++ b/app.py
@@ -428,3 +428,15 @@ def setup_app_context():
 
 if __name__ == '__main__':
     socketio.run(app, debug=True)
+
+
+{'message': 'Recipe successfully shared!', 'code': 200, 
+ 'payload': {'id': 6, 'book_type': 'shared_inbox',
+  'title': 'Shared Recipes', 'description': 'Inbox: Recipes shared by others', 'book_role': 'owner'}, 
+  'recipient_id': 6}
+
+
+{'message': 'Recipe successfully shared!', 'code': 200, 
+ 'payload': {'id': 15, 'book_type': 'shared_inbox',
+'title': 'Shared Recipes', 'description': 'Inbox: Recipes shared by others', 'book_role': 'owner'}, 
+'recipient_id': 7}

--- a/app.py
+++ b/app.py
@@ -284,6 +284,8 @@ def get_book_instructions(authed_user_id, book_id, user_id):
         book_id=book_id, user_id=authed_user_id)
     return jsonify(response)
 
+################################################################################
+
 
 @app.post("/test")
 @verify_jwt_identity
@@ -442,3 +444,18 @@ def setup_app_context():
 if __name__ == '__main__':
     socketio.run(app, debug=True)
 
+
+# !!!!!!!!!!
+# ('edit data:', {'created_by_id': 1, 'name': None, 'ingredients': None, 'instructions': [{'oldId': None, 'newId': 3}], 'notes': None})
+# !!!!!!!!!!
+# !!!!!!!!!!
+# ('instructions:', [{'oldId': None, 'newId': 3}])
+# !!!!!!!!!!
+
+
+# !!!!!!!!!!
+# ('edit data:', {'created_by_id': 1, 'name': None, 'ingredients': None, 'instructions': [{'oldId': None, 'newId': 1}, {'oldId': None, 'newId': 2}], 'notes': None})
+# !!!!!!!!!!
+# !!!!!!!!!!
+# ('instructions:', [{'oldId': None, 'newId': 1}, {'oldId': None, 'newId': 2}])
+# !!!!!!!!!!

--- a/app.py
+++ b/app.py
@@ -393,7 +393,7 @@ def share_recipe(data):
         emit('error_sharing_recipe', {'data': 'Invalid request missing data'})
         return
     try:
-        response = RecipeServices.share_recipe(
+        response = RecipeServices.process_recipe_share(
             auth_id=user_id, recipient=recipient, recipe_id=recipe_id)
 
         if response["code"] in (400, 403, 404, 409):
@@ -416,7 +416,6 @@ def share_recipe(data):
         # else:
             # Future logic to que up message for offline recipient
     except Exception as e:
-        db.session.rollback()
         emit('error_sharing_recipe', {'data': 'Something went wrong'})
         app.logger.error(f"socketio - share_recipe: {e}")
         return

--- a/app.py
+++ b/app.py
@@ -250,7 +250,6 @@ def add_instruction(authed_user_id, book_id, user_id):
 @route_error_handler
 def add_instruction_association(authed_user_id, book_id, instruction_id, user_id):
     """Facilitates association of user instruction to book"""
-    highlight((">>>>",book_id,instruction_id),"!")
     message = InstructionServices.create_instruction_association(
         book_id=book_id, instruction_id=instruction_id)
     return jsonify(message)
@@ -411,7 +410,6 @@ def share_recipe(data):
         recipient_id = connected_users.get(response["recipient_id"])
 
         if recipient_id:
-            highlight(response,"$")
             message = f"{sender} has shared '{recipe}'recipe with you!"
             emit('user_shared_recipe', {"payload":response.get("payload"),
                  "message": message, "recipe": response["recipe"]}, room=recipient_id)
@@ -443,22 +441,3 @@ def setup_app_context():
 
 if __name__ == '__main__':
     socketio.run(app, debug=True)
-
-# replace existing instructions
-# !!!!!!!!!!
-# ('edit data:', {'created_by_id': 1, 'name': None, 'ingredients': None, 'instructions': [{'oldId': 3, 'newId': 4}], 'notes': None})
-# !!!!!!!!!!
-# !!!!!!!!!!
-# ('instructions:', [{'oldId': 3, 'newId': 4}])
-# !!!!!!!!!!
-# !!!!!!!!!!
-# ('query_recipe_instructions', 14, 4)
-# !!!!!!!!!!
-
-# add instruction 
-# !!!!!!!!!!
-# ('edit data:', {'created_by_id': 1, 'name': None, 'ingredients': None,'instructions': [{'oldId': None, 'newId': 2}], 'notes': None})
-# !!!!!!!!!!
-# !!!!!!!!!!
-# ('instructions:', [{'oldId': None, 'newId': 2}])
-# !!!!!!!!!!

--- a/app.py
+++ b/app.py
@@ -395,6 +395,7 @@ def share_recipe(data):
         recipient_id = connected_users.get(response["recipient_id"])
 
         if recipient_id:
+            highlight(response,"$")
             message = f"{sender} has shared '{recipe}'recipe with you!"
             emit('user_shared_recipe', {"payload":response.get("payload"),
                  "message": message, "recipe": response["recipe"]}, room=recipient_id)

--- a/app.py
+++ b/app.py
@@ -283,6 +283,12 @@ def get_book_instructions(authed_user_id, book_id, user_id):
         book_id=book_id, user_id=authed_user_id)
     return jsonify(response)
 
+
+@app.post("/test")
+def test_function(authed_id):
+
+    RecipeServices.share_recipe()
+
 ################################################################################
 
 

--- a/app.py
+++ b/app.py
@@ -250,6 +250,7 @@ def add_instruction(authed_user_id, book_id, user_id):
 @route_error_handler
 def add_instruction_association(authed_user_id, book_id, instruction_id, user_id):
     """Facilitates association of user instruction to book"""
+    highlight((">>>>",book_id,instruction_id),"!")
     message = InstructionServices.create_instruction_association(
         book_id=book_id, instruction_id=instruction_id)
     return jsonify(message)

--- a/models.py
+++ b/models.py
@@ -285,11 +285,10 @@ class BookInstruction(ReprMixin, AssociationTableNameMixin, TimestampMixin, db.M
 
 class RecipeInstruction(ReprMixin, AssociationTableNameMixin, TimestampMixin, db.Model):
     """Association table for recipes and instructions"""
-    id: Mapped[int] = mapped_column(BIGINT, primary_key=True)
     recipe_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("recipes.id", ondelete="CASCADE"))
+        Integer, ForeignKey("recipes.id", ondelete="CASCADE"), primary_key=True)
     instruction_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("instructions.id"))
+        Integer, ForeignKey("instructions.id"), primary_key=True)
 
 
 class AmountBook(ReprMixin, AssociationTableNameMixin, TimestampMixin, db.Model):

--- a/models.py
+++ b/models.py
@@ -93,7 +93,7 @@ class Recipe(ReprMixin, TableNameMixin, TimestampMixin, db.Model):
 
     instructions: Mapped[List['Instruction']] = relationship(
         'Instruction', secondary='recipes_instructions', back_populates='recipes',
-        passive_deletes=True, order_by="RecipeInstruction.id")
+        passive_deletes=True, order_by="RecipeInstruction.created_at")
 
     units: Mapped[List['QuantityUnit']] = relationship(
         "QuantityUnit", secondary='ingredients', back_populates='recipes', viewonly=True)

--- a/models.py
+++ b/models.py
@@ -285,10 +285,11 @@ class BookInstruction(ReprMixin, AssociationTableNameMixin, TimestampMixin, db.M
 
 class RecipeInstruction(ReprMixin, AssociationTableNameMixin, TimestampMixin, db.Model):
     """Association table for recipes and instructions"""
+    id: Mapped[int] = mapped_column(BIGINT, primary_key=True)
     recipe_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("recipes.id", ondelete="CASCADE"), primary_key=True)
+        Integer, ForeignKey("recipes.id", ondelete="CASCADE"))
     instruction_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("instructions.id"), primary_key=True)
+        Integer, ForeignKey("instructions.id"))
 
 
 class AmountBook(ReprMixin, AssociationTableNameMixin, TimestampMixin, db.Model):

--- a/models.py
+++ b/models.py
@@ -5,7 +5,6 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from annotations import str_255, str_unique_255, str_255_nullable, boolean
 from mixins import TableNameMixin, TimestampMixin, ReprMixin, AssociationTableNameMixin
 from typing import Optional, List
-from utils.functions import highlight
 from enum import Enum as PyEnum
 
 

--- a/models.py
+++ b/models.py
@@ -326,7 +326,7 @@ def connect_db(app):
     db.init_app(app)
     with app.app_context():
         try:
-            db.drop_all()
+            # db.drop_all()
             db.create_all()
         except Exception as e:
             print(f"Error creating database tables: {e}")

--- a/models.py
+++ b/models.py
@@ -323,7 +323,7 @@ def connect_db(app):
     db.init_app(app)
     with app.app_context():
         try:
-            db.drop_all()
+            # db.drop_all()
             db.create_all()
         except Exception as e:
             print(f"Error creating database tables: {e}")

--- a/models.py
+++ b/models.py
@@ -326,7 +326,7 @@ def connect_db(app):
     db.init_app(app)
     with app.app_context():
         try:
-            # db.drop_all()
+            db.drop_all()
             db.create_all()
         except Exception as e:
             print(f"Error creating database tables: {e}")

--- a/models.py
+++ b/models.py
@@ -244,10 +244,10 @@ class Ingredient(ReprMixin, TableNameMixin, TimestampMixin, db.Model):
 
 class RecipeBook(ReprMixin, AssociationTableNameMixin, TimestampMixin, db.Model):
     """Association table for books and recipes."""
-    id: Mapped[int] = mapped_column(BIGINT, primary_key=True)
-    book_id: Mapped[int] = mapped_column(Integer, ForeignKey("books.id"))
+    book_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("books.id"), primary_key=True)
     recipe_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("recipes.id", ondelete="CASCADE"))
+        Integer, ForeignKey("recipes.id", ondelete="CASCADE"), primary_key=True)
 
 
 class UserBook(ReprMixin, AssociationTableNameMixin, TimestampMixin, db.Model):
@@ -277,46 +277,42 @@ class UserBook(ReprMixin, AssociationTableNameMixin, TimestampMixin, db.Model):
 
 class BookInstruction(ReprMixin, AssociationTableNameMixin, TimestampMixin, db.Model):
     """Association table for books and instructions"""
-    id: Mapped[int] = mapped_column(BIGINT, primary_key=True)
-    book_id: Mapped[int] = mapped_column(Integer, ForeignKey("books.id"))
+    book_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("books.id"), primary_key=True)
     instruction_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("instructions.id"))
+        Integer, ForeignKey("instructions.id"), primary_key=True)
 
 
 class RecipeInstruction(ReprMixin, AssociationTableNameMixin, TimestampMixin, db.Model):
     """Association table for recipes and instructions"""
-    id: Mapped[int] = mapped_column(BIGINT, primary_key=True)
     recipe_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("recipes.id", ondelete="CASCADE"))
+        Integer, ForeignKey("recipes.id", ondelete="CASCADE"), primary_key=True)
     instruction_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("instructions.id"))
+        Integer, ForeignKey("instructions.id"), primary_key=True)
 
 
 class AmountBook(ReprMixin, AssociationTableNameMixin, TimestampMixin, db.Model):
     """Association table for amounts and books"""
-    id: Mapped[int] = mapped_column(BIGINT, primary_key=True)
     amount_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("quantity_amounts.id", ondelete="CASCADE"))
+        Integer, ForeignKey("quantity_amounts.id", ondelete="CASCADE"), primary_key=True)
     book_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("books.id", ondelete="CASCADE"))
+        Integer, ForeignKey("books.id", ondelete="CASCADE"), primary_key=True)
 
 
 class UnitBook(ReprMixin, AssociationTableNameMixin, TimestampMixin, db.Model):
     """Association table for unit and books"""
-    id: Mapped[int] = mapped_column(BIGINT, primary_key=True)
     unit_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("quantity_units.id", ondelete="CASCADE"))
+        Integer, ForeignKey("quantity_units.id", ondelete="CASCADE"), primary_key=True)
     book_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("books.id", ondelete="CASCADE"))
+        Integer, ForeignKey("books.id", ondelete="CASCADE"), primary_key=True)
 
 
 class ItemBook(ReprMixin, AssociationTableNameMixin, TimestampMixin, db.Model):
     """Association table for items and books"""
-    id: Mapped[int] = mapped_column(BIGINT, primary_key=True)
     item_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("items.id", ondelete="CASCADE"))
+        Integer, ForeignKey("items.id", ondelete="CASCADE"), primary_key=True)
     book_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("books.id", ondelete="CASCADE"))
+        Integer, ForeignKey("books.id", ondelete="CASCADE"), primary_key=True)
 
 
 def connect_db(app):
@@ -326,7 +322,7 @@ def connect_db(app):
     db.init_app(app)
     with app.app_context():
         try:
-            # db.drop_all()
+            db.drop_all()
             db.create_all()
         except Exception as e:
             print(f"Error creating database tables: {e}")

--- a/repository.py
+++ b/repository.py
@@ -132,6 +132,7 @@ class RecipeRepo():
 
 
 # look at payload when User shares with Book with Recipient  - Assigned default book (tester)
+### This looks good
 
 # look at payload when User shares recipe with Recipient - No default book
 # look at payload when User shares recipe with Recipient - Default book is standard 

--- a/repository.py
+++ b/repository.py
@@ -606,7 +606,7 @@ class RecipeInstructionRepo():
         """Query recipe_instruction record. Return recipe_instruction or None"""
         highlight(("query_recipe_instructions",recipe_id, instruction_id),"!")
         try:
-            return db.session.get(
+            return db.session.get(RecipeInstruction,
                 {"recipe_id": recipe_id, "instruction_id": instruction_id})
         except Exception as e:
             raise type(e)(

--- a/repository.py
+++ b/repository.py
@@ -104,6 +104,7 @@ class RecipeRepo():
         recipes will populate in recipient's "Shared Recipes" book. If book does
         not exist one will be created automatically"""
         shared_link = UserBookRepo.query_shared_link(recipient_id=recipient.id)
+        highlight(shared_id,"@")
         book = None
         has_default_book = recipient.default_book_id
         if not shared_link:
@@ -135,15 +136,24 @@ class RecipeRepo():
 ### This looks good
 
 # look at payload when User shares recipe with Recipient - No default book
+###THIS LOOKS GOOD
+
 # look at payload when User shares recipe with Recipient - Default book is standard 
+### recipient's dropdown list is replaced with the one shared book and recipe is render
+### if another book is shared an error is thrown
+### If recipient has standard default book then:
+### message should be shown
+### dropdown should be populated
+### Shared book is not retrieved if recipient already has a shared book
+
+
 # look at payload when User shares recipe with Recipient - Default book is Shared Book
 
             highlight(("is_shared:",is_shared, "has_default_book:",has_default_book),"!")
-
             if not is_shared and has_default_book:
                 msg = RecipeBookRepo.create_entry(
                     book_id=shared_link.book_id, recipe_id=shared_id)
-                
+                highlight(book, "!")
                 book_with_role = BookRepo.build_book(
                     user_id=recipient.id, book_id=book["id"])
                 highlight((msg,book_with_role),"!")
@@ -151,6 +161,7 @@ class RecipeRepo():
             
             highlight(("is_shared:",is_shared, "has_default_book:",has_default_book),"!")
 
+            highlight(book,"!")
             if not is_shared and not has_default_book:
                 RecipeBookRepo.create_entry(
                     book_id=shared_link.book_id, recipe_id=shared_id)

--- a/repository.py
+++ b/repository.py
@@ -78,7 +78,7 @@ class UserRepo():
     @staticmethod
     def _query_by_user(model, association_model, model_fk):
         """Query any resource associated to a user through UserBook.
-        
+
         Args:
             model: The resource model to query (Item, QuantityUnit, QuantityAmount)
             association_model: The association table (ItemBook, UnitBook, AmountBook)
@@ -246,14 +246,9 @@ class QuantityAmountRepo():
     def query_user_amounts(user_id):
         """Return user amounts"""
         try:
-            stmt = (
-                db.select(QuantityAmount)
-                .join(AmountBook, QuantityAmount.id == AmountBook.amount_id)
-                .join(UserBook, AmountBook.book_id == UserBook.book_id)
-                .where(UserBook.user_id == user_id)
-            )
-
-            amounts = db.session.execute(stmt).scalars().all()
+            amounts = UserRepo._query_by_user(
+                QuantityAmount, AmountBook, AmountBook.amount_id)(user_id)
+            
             return [QuantityAmount.serialize(amount) for amount in amounts]
         except Exception as e:
             raise type(e)(
@@ -276,14 +271,9 @@ class QuantityUnitRepo():
     def query_user_units(user_id):
         """Return user's units"""
         try:
-            stmt = (
-                db.select(QuantityUnit)
-                .join(UnitBook, QuantityUnit.id == UnitBook.unit_id)
-                .join(UserBook, UnitBook.book_id == UserBook.book_id)
-                .where(UserBook.user_id == user_id)
-            )
-
-            units = db.session.execute(stmt).scalars().all()
+            units = UserRepo._query_by_user(
+                QuantityUnit, UnitBook, UnitBook.unit_id)(user_id)
+            
             return [QuantityUnit.serialize(unit) for unit in units]
         except Exception as e:
             raise type(e)(
@@ -335,14 +325,8 @@ class ItemRepo():
     def query_user_items(user_id):
         """Return user's items"""
         try:
-            stmt = (
-                db.select(Item)
-                .join(ItemBook, Item.id == ItemBook.item_id)
-                .join(UserBook, ItemBook.book_id == UserBook.book_id)
-                .where(UserBook.user_id == user_id)
-            )
-
-            items = db.session.execute(stmt).scalars().all()
+            items = UserRepo._query_by_user(
+                Item, ItemBook, ItemBook.item_id)(user_id)
             return [Item.serialize(item) for item in items]
         except Exception as e:
             raise type(e)(f"query_user_items error: {e}") from e

--- a/repository.py
+++ b/repository.py
@@ -74,6 +74,25 @@ class UserRepo():
     def hash_password(string):
         """Hashes string sequence"""
         return bcrypt.generate_password_hash(string).decode('UTF-8')
+    
+    @staticmethod
+    def _query_by_user(model, association_model, model_fk):
+        """Query any resource associated to a user through UserBook.
+        
+        Args:
+            model: The resource model to query (Item, QuantityUnit, QuantityAmount)
+            association_model: The association table (ItemBook, UnitBook, AmountBook)
+            model_fk: The FK column on the association table pointing to the model
+        """
+        def query(user_id: int):
+            stmt = (
+                db.select(model)
+                .join(association_model, model.id == model_fk)
+                .join(UserBook, association_model.book_id == UserBook.book_id)
+                .where(UserBook.user_id == user_id)
+            )
+            return db.session.execute(stmt).scalars().all()
+        return query
 
 
 class RecipeRepo():
@@ -257,15 +276,18 @@ class QuantityUnitRepo():
     def query_user_units(user_id):
         """Return user's units"""
         try:
-            units = db.session.query(QuantityUnit).join(
-                UnitBook, QuantityUnit.id == UnitBook.unit_id
-            ).join(
-                UserBook, UnitBook.book_id == UserBook.book_id
-            ).filter(UserBook.user_id == user_id).all()
+            stmt = (
+                db.select(QuantityUnit)
+                .join(UnitBook, QuantityUnit.id == UnitBook.unit_id)
+                .join(UserBook, UnitBook.book_id == UserBook.book_id)
+                .where(UserBook.user_id == user_id)
+            )
+
+            units = db.session.execute(stmt).scalars().all()
             return [QuantityUnit.serialize(unit) for unit in units]
         except Exception as e:
             raise type(e)(
-                f"QuantityUnitRepo - get_all_units error: {e}") from e
+                f"QuantityUnitRepo - query_user_units error: {e}") from e
 
     @staticmethod
     def query_book_units(book_id):
@@ -313,11 +335,14 @@ class ItemRepo():
     def query_user_items(user_id):
         """Return user's items"""
         try:
-            items = db.session.query(Item).join(
-                ItemBook, Item.id == ItemBook.item_id
-            ).join(
-                UserBook, ItemBook.book_id == UserBook.book_id
-            ).filter(UserBook.user_id == user_id).all()
+            stmt = (
+                db.select(Item)
+                .join(ItemBook, Item.id == ItemBook.item_id)
+                .join(UserBook, ItemBook.book_id == UserBook.book_id)
+                .where(UserBook.user_id == user_id)
+            )
+
+            items = db.session.execute(stmt).scalars().all()
             return [Item.serialize(item) for item in items]
         except Exception as e:
             raise type(e)(f"query_user_items error: {e}") from e
@@ -372,9 +397,13 @@ class BookRepo():
         try:
             stmt = db.select(UserBook).where(
                 UserBook.book_id == book_id, UserBook.user_id == user_id)
+            
             user_book = db.session.execute(stmt).scalar_one_or_none()
+
             serialized = Book.serialize(user_book.book)
+
             serialized["book_role"] = user_book.role.value
+
             return serialized
         except Exception as e:
             raise type(e)(f"BookRepo - build_book error: {e}") from e

--- a/repository.py
+++ b/repository.py
@@ -227,11 +227,14 @@ class QuantityAmountRepo():
     def query_user_amounts(user_id):
         """Return user amounts"""
         try:
-            amounts = db.session.query(QuantityAmount).join(
-                AmountBook, QuantityAmount.id == AmountBook.amount_id
-            ).join(
-                UserBook, AmountBook.book_id == UserBook.book_id
-            ).filter(UserBook.user_id == user_id).all()
+            stmt = (
+                db.select(QuantityAmount)
+                .join(AmountBook, QuantityAmount.id == AmountBook.amount_id)
+                .join(UserBook, AmountBook.book_id == UserBook.book_id)
+                .where(UserBook.user_id == user_id)
+            )
+
+            amounts = db.session.execute(stmt).scalars().all()
             return [QuantityAmount.serialize(amount) for amount in amounts]
         except Exception as e:
             raise type(e)(

--- a/repository.py
+++ b/repository.py
@@ -124,7 +124,7 @@ class RecipeRepo():
                 RecipeBookRepo.create_entry(
                     book_id=shared_link.book_id, recipe_id=shared_id)
                 return {"message": "Recipe successfully shared!", "code": 200}
-
+            highlight(("is_shared:",is_shared, "has_default_book:",has_default_book),"#")
             if not is_shared and not has_default_book:
                 RecipeBookRepo.create_entry(
                     book_id=shared_link.book_id, recipe_id=shared_id)

--- a/repository.py
+++ b/repository.py
@@ -365,14 +365,14 @@ class BookRepo():
         """Returns all books associated to user"""
         try:
             user = UserRepo.query_user(user_pk=user_id)
-            books =  [
+            books = [
                 {
                     **Book.serialize(user_book.book),
                     "book_role": user_book.role.value
                 }
                 for user_book in user.user_books
             ]
-            highlight(("books:",books),"!")
+            highlight(("books:", books), "!")
             return books
         except Exception as e:
             raise type(e)(f"BookRepo - get_user_books error: {e}") from e
@@ -579,11 +579,20 @@ class RecipeInstructionRepo():
                 recipe_id=recipe_id, instruction_id=instruction_id)
             db.session.add(entry)
             db.session.flush()
-            return entry.id
+            return entry
         except Exception as e:
             raise type(e)(
                 f"RecipeInstructionRepo - create_entry error :{e}") from e
 
+    @staticmethod
+    def query_recipe_instruction(recipe_id, instruction_id):
+        """Query recipe_instruction record. Return recipe_instruction or None"""
+        try:
+            return db.session.get(
+                {"recipe_id": recipe_id, "instruction_id": instruction_id})
+        except Exception as e:
+            raise type(e)(
+                f"RecipeInstructionRepo - query_recipe_instruction error :{e}") from e
 
 class AmountBookRepo():
     """Facilitates association of amounts & books"""

--- a/repository.py
+++ b/repository.py
@@ -174,21 +174,14 @@ class RecipeRepo():
 
 # look at payload when User shares recipe with Recipient - Default book is Shared Book
 
-            highlight(("is_shared:", is_shared,
-                      "has_default_book:", has_default_book), "!")
             if not is_shared and has_default_book:
                 msg = RecipeBookRepo.create_entry(
                     book_id=shared_link.book_id, recipe_id=shared_id)
-                highlight(book, "!")
 
                 book_with_role = BookRepo.build_book(
                     user_id=recipient.id, book_id=book["id"])
 
-                highlight((msg, book_with_role), "!")
                 return {"message": "Recipe successfully shared!", "code": 200, "payload": book_with_role}
-
-            highlight(("is_shared:", is_shared,
-                      "has_default_book:", has_default_book), "!")
 
         except Exception as e:
             raise type(e)(f"RecipeRepo -> create_recipe_link error:{e}") from e
@@ -379,7 +372,6 @@ class BookRepo():
                 }
                 for user_book in user.user_books
             ]
-            highlight(("books:", books), "!")
             return books
         except Exception as e:
             raise type(e)(f"BookRepo - get_user_books error: {e}") from e
@@ -604,7 +596,6 @@ class RecipeInstructionRepo():
     @staticmethod
     def query_recipe_instruction(recipe_id, instruction_id):
         """Query recipe_instruction record. Return recipe_instruction or None"""
-        highlight(("query_recipe_instructions",recipe_id, instruction_id),"!")
         try:
             return db.session.get(RecipeInstruction,
                 {"recipe_id": recipe_id, "instruction_id": instruction_id})

--- a/repository.py
+++ b/repository.py
@@ -3,7 +3,7 @@ from flask_bcrypt import Bcrypt
 from models import User, db, Recipe, QuantityUnit, QuantityAmount, Item, Book, Instruction, Ingredient, RecipeBook, UserBook, BookInstruction, RecipeInstruction, AmountBook, UnitBook, ItemBook, BookRole, BookType
 from exceptions import *
 from utils.functions import insert_first, highlight
-from werkzeug.exceptions import Conflict, IntegrityError
+from sqlalchemy.exc import IntegrityError
 import logging
 
 logger = logging.getLogger(__name__)

--- a/repository.py
+++ b/repository.py
@@ -74,7 +74,7 @@ class UserRepo():
     def hash_password(string):
         """Hashes string sequence"""
         return bcrypt.generate_password_hash(string).decode('UTF-8')
-    
+
     @staticmethod
     def _query_by_user(model, association_model, model_fk):
         """Query any resource associated to a user through UserBook.
@@ -248,7 +248,7 @@ class QuantityAmountRepo():
         try:
             amounts = UserRepo._query_by_user(
                 QuantityAmount, AmountBook, AmountBook.amount_id)(user_id)
-            
+
             return [QuantityAmount.serialize(amount) for amount in amounts]
         except Exception as e:
             raise type(e)(
@@ -273,7 +273,7 @@ class QuantityUnitRepo():
         try:
             units = UserRepo._query_by_user(
                 QuantityUnit, UnitBook, UnitBook.unit_id)(user_id)
-            
+
             return [QuantityUnit.serialize(unit) for unit in units]
         except Exception as e:
             raise type(e)(
@@ -364,7 +364,7 @@ class BookRepo():
     def query_user_books(user_id):
         """Returns all books associated to user"""
         try:
-            user = db.session.query(User).filter_by(id=user_id).first()
+            user = UserRepo.query_user(user_pk=user_id)
             return [
                 {
                     **Book.serialize(user_book.book),
@@ -377,12 +377,11 @@ class BookRepo():
 
     @staticmethod
     def build_book(user_id, book_id):
-        """Build book object to include 'book_role'"""
+        """Build book object to include 'book_role - !!should be moved to service layer!!'"""
         try:
-            stmt = db.select(UserBook).where(
-                UserBook.book_id == book_id, UserBook.user_id == user_id)
-            
-            user_book = db.session.execute(stmt).scalar_one_or_none()
+
+            user_book = UserBookRepo.query_user_book(
+                book_id=book_id, user_id=user_id)
 
             serialized = Book.serialize(user_book.book)
 
@@ -420,11 +419,8 @@ class InstructionRepo():
     def query_user_instructions(user_id):
         """Query all instructions associated with a user - relying on table join"""
         try:
-            instructions = db.session.query(Instruction).join(
-                BookInstruction, Instruction.id == BookInstruction.instruction_id
-            ).join(
-                UserBook, BookInstruction.book_id == UserBook.book_id
-            ).filter(UserBook.user_id == user_id).all()
+            instructions = UserRepo._query_by_user(
+                Instruction, BookInstruction, BookInstruction.instruction_id)(user_id)
             return [Instruction.serialize(instruction) for instruction in instructions]
         except Exception as e:
             raise type(e)(
@@ -486,7 +482,8 @@ class RecipeBookRepo():
     def remove_book_association(book_id, recipe_id):
         """Delete association sharing recipe to recipient"""
         try:
-            recipe_book = RecipeBookRepo.query_recipe_book(book_id=book_id, recipe_id=recipe_id)
+            recipe_book = RecipeBookRepo.query_recipe_book(
+                book_id=book_id, recipe_id=recipe_id)
             db.session.delete(recipe_book)
             return {"message": "Recipe is no longer shared"}
         except Exception as e:
@@ -520,11 +517,9 @@ class UserBookRepo():
 
     @staticmethod
     def query_user_book(book_id, user_id):
-        """Query UserBook by user id and book id. Return user_book or none"""
+        """Query UserBook by composite  user id and book id. Return user_book or none"""
         try:
-            stmt = db.select(UserBook).filter_by(
-                book_id=book_id, user_id=user_id)
-            return db.session.execute(stmt).scalar_one_or_none()
+            return db.session.get(UserBook, {"book_id": book_id, "user_id": user_id})
         except Exception as e:
             raise type(e)(f"RecipeBookRep - query_user_book error:{e}") from e
 
@@ -532,11 +527,30 @@ class UserBookRepo():
     def query_shared_book(recipient_id):
         """Query for User's "shared recipes" book"""
         try:
-            user_book = UserBook.query.join(Book).filter(
-                UserBook.user_id == recipient_id, Book.book_type == BookType.shared_inbox).first()
+            stmt = (
+                db.select(UserBook)
+                .join(Book, UserBook.book_id == Book.id)
+                .where(
+                    UserBook.user_id == recipient_id,
+                    Book.book_type == BookType.shared_inbox
+                )
+            )
+
+            user_book = db.session.execute(stmt).scalar_one_or_none()
             return user_book
         except Exception as e:
             raise type(e)(f"UserBookRepo - query_shared_book error:{e}") from e
+
+    @staticmethod
+    def query_user_book_ids(user_id, book_id):
+        """Query a list of books ids associated to user"""
+        try:
+            stmt = db.select(UserBook.book_id).where(
+                UserBook.user_id == user_id)
+            return db.session.execute(stmt).scalars().all()
+        except Exception as e:
+            raise type(e)(
+                f"UserBookRepo - query_user_book_ids error:{e}") from e
 
 
 class BookInstructionRepo():

--- a/repository.py
+++ b/repository.py
@@ -119,12 +119,32 @@ class RecipeRepo():
             if is_shared:
                 return {"message": "Recipe already shared with user.",
                         "error": "Conflict", "code": 409}
+# this is not returning book_with_role
+# create logic for when recipient's default book is shared recipes
+# look at payload when not is_shared and has_default_book and has be previously shared
+
+# look at payload when User shares with Book with Recipient  - No default book (tester)
+###Current Book is undefined after default book is created - default book is a complete object
+###On refresh sharing book works
+### Recipients Book dropdown does not dynamically update
+
+# look at payload when User shares recipe with Recipient - No default book
+# look at payload when User shares recipe with Recipient - Default book is standard 
+# look at payload when User shares recipe with Recipient - Default book is Shared Book
+
+            highlight(("is_shared:",is_shared, "has_default_book:",has_default_book),"!")
 
             if not is_shared and has_default_book:
-                RecipeBookRepo.create_entry(
+                msg = RecipeBookRepo.create_entry(
                     book_id=shared_link.book_id, recipe_id=shared_id)
-                return {"message": "Recipe successfully shared!", "code": 200}
-            highlight(("is_shared:",is_shared, "has_default_book:",has_default_book),"#")
+                
+                book_with_role = BookRepo.build_book(
+                    user_id=recipient.id, book_id=book["id"])
+                highlight((msg,book_with_role),"!")
+                return {"message": "Recipe successfully shared!", "code": 200, "payload": book_with_role}
+            
+            highlight(("is_shared:",is_shared, "has_default_book:",has_default_book),"!")
+
             if not is_shared and not has_default_book:
                 RecipeBookRepo.create_entry(
                     book_id=shared_link.book_id, recipe_id=shared_id)

--- a/repository.py
+++ b/repository.py
@@ -452,6 +452,7 @@ class RecipeBookRepo():
         try:
             entry = RecipeBook(book_id=book_id, recipe_id=recipe_id)
             db.session.add(entry)
+            return entry
         except Exception as e:
             raise type(e)(f"RecipeBookRep - create_entry error:{e}") from e
 

--- a/repository.py
+++ b/repository.py
@@ -473,9 +473,8 @@ class RecipeBookRepo():
     def does_recipe_exist_in_shared_inbox(shared_link_id, shared_recipe_id):
         """Query recipe in shared_inbox return value or none"""
         try:
-            stmt = db.select(RecipeBook).where(
-                RecipeBook.book_id == shared_link_id, 
-                RecipeBook.recipe_id == shared_recipe_id)
+            stmt = db.session.get(
+                RecipeBook, {"book_id": shared_link_id, "recipe_id": shared_recipe_id})
             
             return db.session.execute(stmt).scalar_one_or_none()
         except Exception as e:

--- a/repository.py
+++ b/repository.py
@@ -103,9 +103,7 @@ class RecipeRepo():
         """Creates recipe association between User's and Recipient. All shared
         recipes will populate in recipient's "Shared Recipes" book. If book does
         not exist one will be created automatically"""
-        highlight(recipient,"!")
         shared_link = UserBookRepo.query_shared_book(recipient_id=recipient.id)
-        highlight(shared_id,"@")
         book = None
         has_default_book = recipient.default_book_id
         if not shared_link:
@@ -474,13 +472,27 @@ class RecipeBookRepo():
             stmt = db.select(RecipeBook).filter_by(
                 book_id=book_id, recipe_id=recipe_id)
             recipe = db.session.execute(stmt).scalar_one_or_none()
-            highlight(recipe, "$")
             db.session.delete(recipe)
             return {"message": "Recipe is no longer shared"}
         except Exception as e:
             raise type(e)(
                 f"RecipeBookRep - remove_book_association error:{e}") from e
+        
+    @staticmethod
+    def does_recipe_exist_in_shared_inbox(shared_link_id, shared_book_id):
+        """Query recipe in shared_inbox, check if already shared. Return boolean"""
+        try:
+            stmt = db.select(RecipeBook).where(
+                book_id=shared_link_id, recipe_id=shared_book_id)
+            is_shared = db.session.execute(stmt).scalar_one_or_none()
 
+            if is_shared:
+                return {"message": "Recipe already shared with user.",
+                        "error": "Conflict", "code": 409}
+            return None
+        except Exception as e:
+            raise type(e)(
+                f"RecipeBookRep - has_recipe_been_shared error:{e}") from e
 
 class UserBookRepo():
     """Facilitates association of users & books"""

--- a/repository.py
+++ b/repository.py
@@ -3,7 +3,10 @@ from flask_bcrypt import Bcrypt
 from models import User, db, Recipe, QuantityUnit, QuantityAmount, Item, Book, Instruction, Ingredient, RecipeBook, UserBook, BookInstruction, RecipeInstruction, AmountBook, UnitBook, ItemBook, BookRole, BookType
 from exceptions import *
 from utils.functions import insert_first, highlight
-from werkzeug.exceptions import Conflict
+from werkzeug.exceptions import Conflict, IntegrityError
+import logging
+
+logger = logging.getLogger(__name__)
 
 bcrypt = Bcrypt()
 
@@ -26,8 +29,7 @@ class UserRepo():
             db.session.flush()
             token = create_access_token(identity=user.id)
             return token
-        except Exception as e:
-            # can be moved to handle_route_errors
+        except IntegrityError as e:
             if "users_user_name_key" in str(e.orig):
                 raise UsernameAlreadyTakenError(
                     "This username is already taken.") from e
@@ -35,7 +37,12 @@ class UserRepo():
                 raise EmailAlreadyRegisteredError(
                     "This email is already taken.") from e
             else:
+                logger.exception("Unexpected integrity error during signup")
                 raise SignUpError("An error occurred during signup.") from e
+        except Exception as e:
+            # catches everything else
+            logger.exception("Unexpected error during signup")
+            raise SignUpError("An error occurred during signup.") from e
 
     @staticmethod
     def login(user_name, password):
@@ -593,6 +600,7 @@ class RecipeInstructionRepo():
         except Exception as e:
             raise type(e)(
                 f"RecipeInstructionRepo - query_recipe_instruction error :{e}") from e
+
 
 class AmountBookRepo():
     """Facilitates association of amounts & books"""

--- a/repository.py
+++ b/repository.py
@@ -479,17 +479,17 @@ class RecipeBookRepo():
                 f"RecipeBookRep - remove_book_association error:{e}") from e
         
     @staticmethod
-    def does_recipe_exist_in_shared_inbox(shared_link_id, shared_book_id):
+    def does_recipe_exist_in_shared_inbox(shared_link_id, shared_recipe_id):
         """Query recipe in shared_inbox, return message if it already or None"""
         try:
             stmt = db.select(RecipeBook).where(
-                book_id=shared_link_id, recipe_id=shared_book_id)
+                book_id=shared_link_id, recipe_id=shared_recipe_id)
             is_shared = db.session.execute(stmt).scalar_one_or_none()
 
             if is_shared:
                 return {"message": "Recipe already shared with user.",
                         "error": "Conflict", "code": 409}
-            return None
+            return is_shared
         except Exception as e:
             raise type(e)(
                 f"RecipeBookRep - has_recipe_been_shared error:{e}") from e

--- a/repository.py
+++ b/repository.py
@@ -407,9 +407,12 @@ class InstructionRepo():
     def create_instruction(instruction):
         """Create and add instruction to database"""
         try:
+            highlight(("in coming create instructions",instruction),"!")
             instruction = Instruction(instruction=instruction)
             db.session.add(instruction)
             db.session.flush()
+            highlight(("out going create instructions",
+                      Instruction.serialize(instruction)), "!")
             return Instruction.serialize(instruction)
         except Exception as e:
             raise type(e)(
@@ -604,6 +607,7 @@ class RecipeInstructionRepo():
     @staticmethod
     def query_recipe_instruction(recipe_id, instruction_id):
         """Query recipe_instruction record. Return recipe_instruction or None"""
+        highlight(("query_recipe_instructions",recipe_id, instruction_id),"!")
         try:
             return db.session.get(
                 {"recipe_id": recipe_id, "instruction_id": instruction_id})

--- a/repository.py
+++ b/repository.py
@@ -106,11 +106,9 @@ class RecipeRepo():
         shared_link = UserBookRepo.query_shared_link(recipient_id=recipient.id)
         book = None
         has_default_book = recipient.default_book_id
-        highlight(book, "!")
         if not shared_link:
             book = BookRepo.create_book(title="Shared Recipes",
                                         description="Inbox: Recipes shared by others", book_type=BookType.shared_inbox)
-            highlight(book,"!")
 
             shared_link = UserBookRepo.create_entry(
                 user_id=recipient.id, book_id=book["id"])
@@ -130,15 +128,12 @@ class RecipeRepo():
             if not is_shared and not has_default_book:
                 RecipeBookRepo.create_entry(
                     book_id=shared_link.book_id, recipe_id=shared_id)
-                highlight(has_default_book,"1")
-                highlight(book,"2")
                 recipient.default_book_id = book["id"]
 
                 book_with_role = BookRepo.build_book(
                     user_id=recipient.id, book_id=book["id"])
-                highlight(book_with_role, "3")
 
-                return {"message": "process payload", "code": 200, "payload": book_with_role}
+                return {"message": "Recipe successfully shared!", "code": 200, "payload": book_with_role}
 
         except Exception as e:
             raise type(e)(f"RecipeRepo -> create_recipe_link error:{e}") from e

--- a/repository.py
+++ b/repository.py
@@ -365,13 +365,15 @@ class BookRepo():
         """Returns all books associated to user"""
         try:
             user = UserRepo.query_user(user_pk=user_id)
-            return [
+            books =  [
                 {
                     **Book.serialize(user_book.book),
                     "book_role": user_book.role.value
                 }
                 for user_book in user.user_books
             ]
+            highlight(("books:",books),"!")
+            return books
         except Exception as e:
             raise type(e)(f"BookRepo - get_user_books error: {e}") from e
 

--- a/repository.py
+++ b/repository.py
@@ -126,7 +126,12 @@ class RecipeRepo():
 # look at payload when User shares with Book with Recipient  - No default book (tester)
 ###Current Book is undefined after default book is created - default book is a complete object
 ###On refresh sharing book works
-### Recipients Book dropdown does not dynamically update
+### Client needed to have context updated with relevant data
+### Now book needs to populate for recipient``
+### This look good!
+
+
+# look at payload when User shares with Book with Recipient  - Assigned default book (tester)
 
 # look at payload when User shares recipe with Recipient - No default book
 # look at payload when User shares recipe with Recipient - Default book is standard 

--- a/repository.py
+++ b/repository.py
@@ -100,17 +100,20 @@ class RecipeRepo():
             raise type(e)(f"RecipeRepo -> create_recipe error:{e}") from e
 
     @staticmethod
-    def create_recipe_link(recipient_id, shared_id):
+    def create_recipe_link(recipient, shared_id):
         """Creates recipe association between User's and Recipient. All shared
         recipes will populate in recipient's "Shared Recipes" book. If book does
         not exist one will be created automatically"""
-        shared_link = UserBookRepo.query_shared_link(recipient_id=recipient_id)
+        shared_link = UserBookRepo.query_shared_link(recipient_id=recipient.id)
 
         if not shared_link:
             book = BookRepo.create_book(title="Shared Recipes",
                                         description="Inbox: Recipes shared by others", book_type=BookType.shared_inbox)
+            
+            recipient.default_book_id = book["id"]
+
             shared_link = UserBookRepo.create_entry(
-                user_id=recipient_id, book_id=book["id"])
+                user_id=recipient.id, book_id=book["id"])
         try:
             is_shared = RecipeBook.query.filter_by(
                 book_id=shared_link.book_id, recipe_id=shared_id).first()

--- a/repository.py
+++ b/repository.py
@@ -407,12 +407,9 @@ class InstructionRepo():
     def create_instruction(instruction):
         """Create and add instruction to database"""
         try:
-            highlight(("in coming create instructions",instruction),"!")
             instruction = Instruction(instruction=instruction)
             db.session.add(instruction)
             db.session.flush()
-            highlight(("out going create instructions",
-                      Instruction.serialize(instruction)), "!")
             return Instruction.serialize(instruction)
         except Exception as e:
             raise type(e)(

--- a/repository.py
+++ b/repository.py
@@ -352,7 +352,7 @@ class BookRepo():
         """Query book by pk. Return none if not found"""
         try:
             stmt = db.select(Book).where(Book.id == book_pk)
-            db.session.execute(stmt).scalar_one_or_none()
+            return db.session.execute(stmt).scalar_one_or_none()
         except Exception as e:
             raise type(e)(
                 f"BookRepo - query_user_book_by_pk error: {e}") from e

--- a/repository.py
+++ b/repository.py
@@ -575,6 +575,16 @@ class BookInstructionRepo():
             raise type(e)(
                 f"BookInstructionRepo - create_entry error :{e}") from e
 
+    @staticmethod
+    def query_book_instruction(book_id, instruction_id):
+        """Query books_instructions by composite key. Return instance or None"""
+        try:
+            return db.session.get(BookInstruction, {'book_id': book_id,
+                                                    "instruction_id": instruction_id})
+        except Exception as e:
+            raise type(e)(
+                f"BookInstructionRepo - query_book_instruction error :{e}") from e
+
 
 class RecipeInstructionRepo():
     """Facilitates association of recipes & instructions"""

--- a/repository.py
+++ b/repository.py
@@ -113,8 +113,8 @@ class RecipeRepo():
             shared_link = UserBookRepo.create_entry(
                 user_id=recipient.id, book_id=book["id"])
         try:
-            is_shared = RecipeBook.query.filter_by(
-                book_id=shared_link.book_id, recipe_id=shared_id).first()
+            is_shared = RecipeBookRepo.query_recipe_book(
+                book_id=shared_link.book_id, recipe_id=shared_id)
 
             if is_shared:
                 return {"message": "Recipe already shared with user.",
@@ -157,7 +157,7 @@ class RecipeRepo():
 
                 book_with_role = BookRepo.build_book(
                     user_id=recipient.id, book_id=book["id"])
-                
+
                 highlight((msg, book_with_role), "!")
                 return {"message": "Recipe successfully shared!", "code": 200, "payload": book_with_role}
 
@@ -448,6 +448,15 @@ class RecipeIngredientRepo():
 class RecipeBookRepo():
     """Facilitates association of recipes & books"""
     @staticmethod
+    def query_recipe_book(book_id, recipe_id):
+        """Return recipe book instance by composite key"""
+        try:
+            return RecipeBookRepo.query_recipe_book(book_id=book_id, recipe_id=recipe_id)
+        except Exception as e:
+            raise type(e)(
+                f"RecipeBookRep - query_recipe_book error:{e}") from e
+
+    @staticmethod
     def create_entry(book_id, recipe_id):
         """Create recipe and book association -> add to database"""
         try:
@@ -461,8 +470,7 @@ class RecipeBookRepo():
     def remove_book_association(book_id, recipe_id):
         """Delete association sharing recipe to recipient"""
         try:
-            recipe_book = db.session.get(
-                RecipeBook, {"book_id": book_id, "recipe_id": recipe_id})
+            recipe_book = RecipeBookRepo.query_recipe_book(book_id=book_id, recipe_id=recipe_id)
             db.session.delete(recipe_book)
             return {"message": "Recipe is no longer shared"}
         except Exception as e:
@@ -473,10 +481,8 @@ class RecipeBookRepo():
     def does_recipe_exist_in_shared_inbox(shared_link_id, shared_recipe_id):
         """Query recipe in shared_inbox return value or none"""
         try:
-            stmt = db.session.get(
-                RecipeBook, {"book_id": shared_link_id, "recipe_id": shared_recipe_id})
-            
-            return db.session.execute(stmt).scalar_one_or_none()
+            return RecipeBookRepo.query_recipe_book(
+                book_id=shared_link_id, recipe_id=shared_recipe_id)
         except Exception as e:
             raise type(e)(
                 f"RecipeBookRep - does_recipe_exist_in_shared_inbox error:{e}") from e

--- a/repository.py
+++ b/repository.py
@@ -160,16 +160,6 @@ class RecipeRepo():
             
             highlight(("is_shared:",is_shared, "has_default_book:",has_default_book),"!")
 
-            highlight(book,"!")
-            if not is_shared and not has_default_book:
-                RecipeBookRepo.create_entry(
-                    book_id=shared_link.book_id, recipe_id=shared_id)
-                recipient.default_book_id = book["id"]
-
-                book_with_role = BookRepo.build_book(
-                    user_id=recipient.id, book_id=book["id"])
-
-                return {"message": "Recipe successfully shared!", "code": 200, "payload": book_with_role}
 
         except Exception as e:
             raise type(e)(f"RecipeRepo -> create_recipe_link error:{e}") from e

--- a/repository.py
+++ b/repository.py
@@ -103,7 +103,8 @@ class RecipeRepo():
         """Creates recipe association between User's and Recipient. All shared
         recipes will populate in recipient's "Shared Recipes" book. If book does
         not exist one will be created automatically"""
-        shared_link = UserBookRepo.query_shared_link(recipient_id=recipient.id)
+        highlight(recipient,"!")
+        shared_link = UserBookRepo.query_shared_book(recipient_id=recipient.id)
         highlight(shared_id,"@")
         book = None
         has_default_book = recipient.default_book_id
@@ -345,6 +346,16 @@ class BookRepo():
             return Book.serialize(book)
         except Exception as e:
             raise type(e)(f"create_book error: {e}") from e
+        
+    @staticmethod
+    def query_user_book_by_pk(book_pk):
+        """Query book by pk. Return none if not found"""
+        try:
+            stmt = db.select(Book).where(Book.id == book_pk)
+            db.session.execute(stmt).scalar_one_or_none()
+        except Exception as e:
+            raise type(e)(
+                f"BookRepo - query_user_book_by_pk error: {e}") from e
 
     @staticmethod
     def query_user_books(user_id):
@@ -496,14 +507,14 @@ class UserBookRepo():
             raise type(e)(f"RecipeBookRep - query_user_book error:{e}") from e
 
     @staticmethod
-    def query_shared_link(recipient_id):
+    def query_shared_book(recipient_id):
         """Query for User's "shared recipes" book"""
         try:
             user_book = UserBook.query.join(Book).filter(
                 UserBook.user_id == recipient_id, Book.book_type == BookType.shared_inbox).first()
             return user_book
         except Exception as e:
-            raise type(e)(f"UserBookRepo - query_shared_link error:{e}") from e
+            raise type(e)(f"UserBookRepo - query_shared_book error:{e}") from e
 
 
 class BookInstructionRepo():

--- a/repository.py
+++ b/repository.py
@@ -99,7 +99,7 @@ class RecipeRepo():
             raise type(e)(f"RecipeRepo -> create_recipe error:{e}") from e
 
     @staticmethod
-    def create_recipe_link(recipient, shared_id):
+    def create_recipe_lik(recipient, shared_id):
         """Creates recipe association between User's and Recipient. All shared
         recipes will populate in recipient's "Shared Recipes" book. If book does
         not exist one will be created automatically"""
@@ -124,42 +124,45 @@ class RecipeRepo():
 # look at payload when not is_shared and has_default_book and has be previously shared
 
 # look at payload when User shares with Book with Recipient  - No default book (tester)
-###Current Book is undefined after default book is created - default book is a complete object
-###On refresh sharing book works
-### Client needed to have context updated with relevant data
-### Now book needs to populate for recipient``
-### This look good!
+# Current Book is undefined after default book is created - default book is a complete object
+# On refresh sharing book works
+# Client needed to have context updated with relevant data
+# Now book needs to populate for recipient``
+# This look good!
 
 
 # look at payload when User shares with Book with Recipient  - Assigned default book (tester)
-### This looks good
+# This looks good
 
 # look at payload when User shares recipe with Recipient - No default book
-###THIS LOOKS GOOD
+# THIS LOOKS GOOD
 
-# look at payload when User shares recipe with Recipient - Default book is standard 
-### recipient's dropdown list is replaced with the one shared book and recipe is render
-### if another book is shared an error is thrown
-### If recipient has standard default book then:
-### message should be shown
-### dropdown should be populated
-### Shared book is not retrieved if recipient already has a shared book
+# look at payload when User shares recipe with Recipient - Default book is standard
+# recipient's dropdown list is replaced with the one shared book and recipe is render
+# if another book is shared an error is thrown
+# If recipient has standard default book then:
+# message should be shown
+# dropdown should be populated
+# Shared book is not retrieved if recipient already has a shared book
 
 
 # look at payload when User shares recipe with Recipient - Default book is Shared Book
 
-            highlight(("is_shared:",is_shared, "has_default_book:",has_default_book),"!")
+            highlight(("is_shared:", is_shared,
+                      "has_default_book:", has_default_book), "!")
             if not is_shared and has_default_book:
                 msg = RecipeBookRepo.create_entry(
                     book_id=shared_link.book_id, recipe_id=shared_id)
                 highlight(book, "!")
+
                 book_with_role = BookRepo.build_book(
                     user_id=recipient.id, book_id=book["id"])
-                highlight((msg,book_with_role),"!")
+                
+                highlight((msg, book_with_role), "!")
                 return {"message": "Recipe successfully shared!", "code": 200, "payload": book_with_role}
-            
-            highlight(("is_shared:",is_shared, "has_default_book:",has_default_book),"!")
 
+            highlight(("is_shared:", is_shared,
+                      "has_default_book:", has_default_book), "!")
 
         except Exception as e:
             raise type(e)(f"RecipeRepo -> create_recipe_link error:{e}") from e
@@ -334,7 +337,7 @@ class BookRepo():
             return Book.serialize(book)
         except Exception as e:
             raise type(e)(f"create_book error: {e}") from e
-        
+
     @staticmethod
     def query_user_book_by_pk(book_pk):
         """Query book by pk. Return none if not found"""
@@ -395,7 +398,6 @@ class InstructionRepo():
             instructions = Instruction.query.all()
             return [Instruction.serialize(instruction) for instruction in instructions]
         except Exception as e:
-            # db.session.rollback()
             raise type(e)(f"InstructionRepo - get_instruction error: {e}")
 
     @staticmethod
@@ -409,7 +411,6 @@ class InstructionRepo():
             ).filter(UserBook.user_id == user_id).all()
             return [Instruction.serialize(instruction) for instruction in instructions]
         except Exception as e:
-            # db.session.rollback()
             raise type(e)(
                 f"InstructionRepo - get_user_instructions error: {e}")
 
@@ -460,30 +461,27 @@ class RecipeBookRepo():
     def remove_book_association(book_id, recipe_id):
         """Delete association sharing recipe to recipient"""
         try:
-            stmt = db.select(RecipeBook).filter_by(
-                book_id=book_id, recipe_id=recipe_id)
-            recipe = db.session.execute(stmt).scalar_one_or_none()
-            db.session.delete(recipe)
+            recipe_book = db.session.get(
+                RecipeBook, {"book_id": book_id, "recipe_id": recipe_id})
+            db.session.delete(recipe_book)
             return {"message": "Recipe is no longer shared"}
         except Exception as e:
             raise type(e)(
                 f"RecipeBookRep - remove_book_association error:{e}") from e
-        
+
     @staticmethod
     def does_recipe_exist_in_shared_inbox(shared_link_id, shared_recipe_id):
-        """Query recipe in shared_inbox, return message if it already or None"""
+        """Query recipe in shared_inbox return value or none"""
         try:
             stmt = db.select(RecipeBook).where(
-                book_id=shared_link_id, recipe_id=shared_recipe_id)
-            is_shared = db.session.execute(stmt).scalar_one_or_none()
-
-            if is_shared:
-                return {"message": "Recipe already shared with user.",
-                        "error": "Conflict", "code": 409}
-            return is_shared
+                RecipeBook.book_id == shared_link_id, 
+                RecipeBook.recipe_id == shared_recipe_id)
+            
+            return db.session.execute(stmt).scalar_one_or_none()
         except Exception as e:
             raise type(e)(
-                f"RecipeBookRep - has_recipe_been_shared error:{e}") from e
+                f"RecipeBookRep - does_recipe_exist_in_shared_inbox error:{e}") from e
+
 
 class UserBookRepo():
     """Facilitates association of users & books"""

--- a/repository.py
+++ b/repository.py
@@ -480,7 +480,7 @@ class RecipeBookRepo():
         
     @staticmethod
     def does_recipe_exist_in_shared_inbox(shared_link_id, shared_book_id):
-        """Query recipe in shared_inbox, check if already shared. Return boolean"""
+        """Query recipe in shared_inbox, return message if it already or None"""
         try:
             stmt = db.select(RecipeBook).where(
                 book_id=shared_link_id, recipe_id=shared_book_id)

--- a/repository.py
+++ b/repository.py
@@ -69,7 +69,6 @@ class UserRepo():
             return db.session.execute(stmt).scalar_one_or_none()
         except Exception as e:
             raise type(e)(f"UserRepo -> query_user_name error:{e}") from e
-        
 
     @staticmethod
     def hash_password(string):
@@ -105,25 +104,42 @@ class RecipeRepo():
         recipes will populate in recipient's "Shared Recipes" book. If book does
         not exist one will be created automatically"""
         shared_link = UserBookRepo.query_shared_link(recipient_id=recipient.id)
-
+        book = None
+        has_default_book = recipient.default_book_id
+        highlight(book, "!")
         if not shared_link:
             book = BookRepo.create_book(title="Shared Recipes",
                                         description="Inbox: Recipes shared by others", book_type=BookType.shared_inbox)
-            
-            recipient.default_book_id = book["id"]
+            highlight(book,"!")
 
             shared_link = UserBookRepo.create_entry(
                 user_id=recipient.id, book_id=book["id"])
         try:
             is_shared = RecipeBook.query.filter_by(
                 book_id=shared_link.book_id, recipe_id=shared_id).first()
+
             if is_shared:
                 return {"message": "Recipe already shared with user.",
                         "error": "Conflict", "code": 409}
-            if not is_shared:
+
+            if not is_shared and has_default_book:
                 RecipeBookRepo.create_entry(
                     book_id=shared_link.book_id, recipe_id=shared_id)
-                return {"message": "Recipe successfully shared!","code":200}
+                return {"message": "Recipe successfully shared!", "code": 200}
+
+            if not is_shared and not has_default_book:
+                RecipeBookRepo.create_entry(
+                    book_id=shared_link.book_id, recipe_id=shared_id)
+                highlight(has_default_book,"1")
+                highlight(book,"2")
+                recipient.default_book_id = book["id"]
+
+                book_with_role = BookRepo.build_book(
+                    user_id=recipient.id, book_id=book["id"])
+                highlight(book_with_role, "3")
+
+                return {"message": "process payload", "code": 200, "payload": book_with_role}
+
         except Exception as e:
             raise type(e)(f"RecipeRepo -> create_recipe_link error:{e}") from e
 
@@ -312,12 +328,13 @@ class BookRepo():
             ]
         except Exception as e:
             raise type(e)(f"BookRepo - get_user_books error: {e}") from e
-        
+
     @staticmethod
     def build_book(user_id, book_id):
         """Build book object to include 'book_role'"""
         try:
-            stmt = db.select(UserBook).where(UserBook.book_id==book_id,UserBook.user_id==user_id)
+            stmt = db.select(UserBook).where(
+                UserBook.book_id == book_id, UserBook.user_id == user_id)
             user_book = db.session.execute(stmt).scalar_one_or_none()
             serialized = Book.serialize(user_book.book)
             serialized["book_role"] = user_book.role.value
@@ -406,19 +423,21 @@ class RecipeBookRepo():
             db.session.add(entry)
         except Exception as e:
             raise type(e)(f"RecipeBookRep - create_entry error:{e}") from e
-        
+
     @staticmethod
     def remove_book_association(book_id, recipe_id):
         """Delete association sharing recipe to recipient"""
         try:
-            stmt = db.select(RecipeBook).filter_by(book_id=book_id,recipe_id=recipe_id)
+            stmt = db.select(RecipeBook).filter_by(
+                book_id=book_id, recipe_id=recipe_id)
             recipe = db.session.execute(stmt).scalar_one_or_none()
-            highlight(recipe,"$")
+            highlight(recipe, "$")
             db.session.delete(recipe)
-            return {"message":"Recipe is no longer shared"}
+            return {"message": "Recipe is no longer shared"}
         except Exception as e:
-            raise type(e)(f"RecipeBookRep - remove_book_association error:{e}") from e
-        
+            raise type(e)(
+                f"RecipeBookRep - remove_book_association error:{e}") from e
+
 
 class UserBookRepo():
     """Facilitates association of users & books"""
@@ -438,11 +457,12 @@ class UserBookRepo():
     def query_user_book(book_id, user_id):
         """Query UserBook by user id and book id. Return user_book or none"""
         try:
-            stmt = db.select(UserBook).filter_by(book_id=book_id,user_id=user_id)
+            stmt = db.select(UserBook).filter_by(
+                book_id=book_id, user_id=user_id)
             return db.session.execute(stmt).scalar_one_or_none()
         except Exception as e:
             raise type(e)(f"RecipeBookRep - query_user_book error:{e}") from e
-        
+
     @staticmethod
     def query_shared_link(recipient_id):
         """Query for User's "shared recipes" book"""

--- a/services/book_services.py
+++ b/services/book_services.py
@@ -83,3 +83,11 @@ class BookServices():
         except Exception as e:
             db.session.rollback()
             raise
+
+    @staticmethod
+    def share_book_no_default_book():
+        """User shares Book with Recipient that has no default book assigned"""
+
+    @staticmethod
+    def share_book_has_default_book():
+        """User shares with Recipient that has assigned default book"""

--- a/services/book_services.py
+++ b/services/book_services.py
@@ -67,7 +67,6 @@ class BookServices():
                     user_id=recipient.id, book_id=book_id, role=BookRole.collaborator)
                 
                 is_default_assigned = UserServices.assign_default_book_if_none_set(user_id=recipient.id, book_id=book_id)
-                highlight(book,"!")
                 if is_default_assigned:
                     book_with_role = BookRepo.build_book(
                         user_id=recipient.id, book_id=book.book_id)

--- a/services/book_services.py
+++ b/services/book_services.py
@@ -68,11 +68,16 @@ class BookServices():
                     book_with_role = BookRepo.build_book(
                         user_id=recipient.id, book_id=book.book_id)
                     
+                    db.session.commit()
+                    return {"recipient_id": recipient.id,
+                            "message": f"Book shared with {recipient.user_name}!",
+                            "code": 200,
+                            "payload":book_with_role
+                            }
                 db.session.commit()
                 return {"recipient_id": recipient.id,
                         "message": f"Book shared with {recipient.user_name}!",
-                        "code": 200,
-                        "payload":book_with_role
+                        "code": 200
                         }
                 
         except Exception as e:

--- a/services/book_services.py
+++ b/services/book_services.py
@@ -17,13 +17,17 @@ class BookServices():
         try:
             new_book = BookRepo.create_book(
                 title=book_data["title"], description=book_data["description"])
+            
             # associate book to user
             if new_book["id"]:
-                UserBookRepo.create_entry(
+                user_book = UserBookRepo.create_entry(
                     user_id=user_id, book_id=new_book["id"])
+                new_book["book_role"] = user_book.role.value
+            
             # add book id to default if necessary
             UserServices.assign_default_book_if_none_set(
                 user_id=user_id, book_id=new_book["id"])
+            
             db.session.commit()
             return new_book
         except Exception as e:

--- a/services/book_services.py
+++ b/services/book_services.py
@@ -58,14 +58,21 @@ class BookServices():
                 return {"message": "User already has access to this book!",
                         "error": "Unprocessable Content", "code": 409
                         }
-            else:
-                UserBookRepo.create_entry(
+            if not relation_exists:
+                book = UserBookRepo.create_entry(
                     user_id=recipient.id, book_id=book_id, role=BookRole.collaborator)
-                UserServices.assign_default_book_if_none_set(user_id=recipient.id, book_id=book_id)
+                
+                is_default_assigned = UserServices.assign_default_book_if_none_set(user_id=recipient.id, book_id=book_id)
+                highlight(book,"!")
+                if is_default_assigned:
+                    book_with_role = BookRepo.build_book(
+                        user_id=recipient.id, book_id=book.book_id)
+                    
                 db.session.commit()
                 return {"recipient_id": recipient.id,
                         "message": f"Book shared with {recipient.user_name}!",
-                        "code": 200
+                        "code": 200,
+                        "payload":book_with_role
                         }
                 
         except Exception as e:

--- a/services/book_services.py
+++ b/services/book_services.py
@@ -52,7 +52,7 @@ class BookServices():
                         "error": "Unprocessable Content", "code": 422
                         }
             
-            relation_exists = db.session.get(UserBook, (book_id, recipient.id))
+            relation_exists = UserBookRepo.query_shared_book(book_id=book_id, user_id=recipient.id)
 
             if relation_exists:
                 return {"message": "User already has access to this book!",

--- a/services/instructions_services.py
+++ b/services/instructions_services.py
@@ -1,8 +1,9 @@
-from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError, ProgrammingError
 from repository import InstructionRepo
 from models import db, Instruction, RecipeInstruction
 from repository import UserBookRepo, BookInstructionRepo
-from sqlalchemy.exc import ProgrammingError
+from werkzeug.exceptions import Conflict
+from utils.functions import highlight
 
 class InstructionServices():
     """Handles instructions view business logic"""
@@ -35,7 +36,8 @@ class InstructionServices():
     def check_book_access(user_id, book_id):
         """Authorizes user access to book"""
         try:
-            book_ids = UserBookRepo.query_user_book_ids(user_id=user_id, book_id=book_id)
+            book_ids = UserBookRepo.query_user_book_ids(
+                user_id=user_id, book_id=book_id)
             if int(book_id) in book_ids:
                 return True
             else:
@@ -63,7 +65,15 @@ class InstructionServices():
     @staticmethod
     def create_instruction_association(book_id, instruction_id):
         """Associate user instruction to book"""
+        highlight("IN HERE","!")
+        # return {"message":
+        #         f"Successful association of instruction {instruction_id} to book {book_id}!"}
         try:
+            exists = BookInstructionRepo.query_book_instruction(
+                book_id=book_id, instruction_id=instruction_id)
+            if exists:
+                return
+            
             BookInstructionRepo.create_entry(
                 book_id=book_id, instruction_id=instruction_id)
             db.session.commit()

--- a/services/instructions_services.py
+++ b/services/instructions_services.py
@@ -1,7 +1,7 @@
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from repository import InstructionRepo
 from models import db, Instruction, RecipeInstruction
-from repository import UserBook, BookInstructionRepo
+from repository import UserBookRepo, BookInstructionRepo
 from sqlalchemy.exc import ProgrammingError
 
 class InstructionServices():
@@ -35,8 +35,7 @@ class InstructionServices():
     def check_book_access(user_id, book_id):
         """Authorizes user access to book"""
         try:
-            book_ids = [book_id[0] for book_id in db.session.query(
-                UserBook.book_id).filter(UserBook.user_id == user_id).all()]
+            book_ids = UserBookRepo.query_user_book_ids(user_id=user_id, book_id=book_id)
             if int(book_id) in book_ids:
                 return True
             else:

--- a/services/instructions_services.py
+++ b/services/instructions_services.py
@@ -1,7 +1,7 @@
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError, ProgrammingError
 from repository import InstructionRepo
-from models import db, Instruction, RecipeInstruction
-from repository import UserBookRepo, BookInstructionRepo
+from models import db, Instruction
+from repository import UserBookRepo, BookInstructionRepo, RecipeInstructionRepo
 from werkzeug.exceptions import Conflict
 from utils.functions import highlight
 
@@ -83,28 +83,16 @@ class InstructionServices():
                 f"Error in InstructionServices -> create_instruction_association: {e}") from e
 
     @staticmethod
-    def process_instructions(instructions, book_id):
+    def process_instructions(instructions, recipe_id):
         """Adds new recipe instructions - Consolidates existing and new instruction objects - associates instruction to book """
-        processed_instructions = []
-        highlight(("process instructions",instructions),"!")
         for instruction in instructions:
-            is_stored = instruction.get("id")
-            if is_stored is None:
-                try:
-                    # is this neccessry, all recipe instructions should already be created
-                    instruction = InstructionRepo.create_instruction(
-                        instruction=instruction["instruction"])
-                    
-                    processed_instructions.append(instruction)
-
-                    BookInstructionRepo.create_entry(
-                        book_id=book_id, instruction_id=instruction.id)
-                except Exception as e:
-                    raise type(e)(
-                        f"Error in InstructionServices - process_instructions: {e}")
-            else:
-                processed_instructions.append(instruction)
-        return processed_instructions
+            try:
+                RecipeInstructionRepo.create_entry(recipe_id=recipe_id, instruction_id=instruction["id"])
+            except Exception as e:
+                db.session.rollback()
+                raise type(e)(
+                    f"Error in InstructionServices - process_instructions: {e}") from e
+        return instructions
 
     @staticmethod
     def build_instructions(instances):

--- a/services/instructions_services.py
+++ b/services/instructions_services.py
@@ -86,6 +86,7 @@ class InstructionServices():
     def process_instructions(instructions, book_id):
         """Adds new recipe instructions - Consolidates existing and new instruction objects - associates instruction to book """
         processed_instructions = []
+        highlight(("process instructions",instructions),"!")
         for instruction in instructions:
             is_stored = instruction.get("id")
             if is_stored is None:
@@ -93,7 +94,9 @@ class InstructionServices():
                     # is this neccessry, all recipe instructions should already be created
                     instruction = InstructionRepo.create_instruction(
                         instruction=instruction["instruction"])
+                    
                     processed_instructions.append(instruction)
+
                     BookInstructionRepo.create_entry(
                         book_id=book_id, instruction_id=instruction.id)
                 except Exception as e:

--- a/services/instructions_services.py
+++ b/services/instructions_services.py
@@ -84,7 +84,7 @@ class InstructionServices():
 
     @staticmethod
     def process_instructions(instructions, recipe_id):
-        """Adds new recipe instructions - Consolidates existing and new instruction objects - associates instruction to book """
+        """Associates instructions to recipe """
         for instruction in instructions:
             try:
                 RecipeInstructionRepo.create_entry(recipe_id=recipe_id, instruction_id=instruction["id"])

--- a/services/instructions_services.py
+++ b/services/instructions_services.py
@@ -96,28 +96,12 @@ class InstructionServices():
         return processed_instructions
 
     @staticmethod
-    def build_instructions(instances, recipe_id):
-        """Return all associated instructions from recipe instance and updated with 
-        recipe_instruction identifier"""
-        instructions = []
+    def build_instructions(instances):
+        """Return serialized instructions instructions instance"""
         if not instances:
             return []
         try:
-            for instruction_instance in instances:
-                instruction = Instruction.serialize(instruction_instance)
-                # inject PK from recipes_instructions association table
-                association_id = RecipeInstruction.query.filter_by(
-                    recipe_id=recipe_id,
-                    instruction_id=instruction["id"]).scalar().id
-
-                if not association_id:
-                    raise ValueError(
-                        f"Association not found for instruction ID {instruction['id']} in recipe {recipe_id}")
-
-                instruction["association_id"] = association_id
-                instructions.append(instruction)
-
-            return instructions
+            return [Instruction.serialize(instruction_instance) for instruction_instance in instances]
         except Exception as e:
             raise type(e)(
                 f"InstructionServices - build_instructions error: {e}") from e

--- a/services/instructions_services.py
+++ b/services/instructions_services.py
@@ -65,10 +65,8 @@ class InstructionServices():
     @staticmethod
     def create_instruction_association(book_id, instruction_id):
         """Associate user instruction to book"""
-        highlight("IN HERE","!")
-        # return {"message":
-        #         f"Successful association of instruction {instruction_id} to book {book_id}!"}
         try:
+            # prevents User from creating duplicate association to book
             exists = BookInstructionRepo.query_book_instruction(
                 book_id=book_id, instruction_id=instruction_id)
             if exists:

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -313,7 +313,7 @@ class RecipeServices():
         """User shares recipe with Recipient that has no default book assigned"""
         response = RecipeServices.fetch_shared_link(
             recipient_id=recipient.id, shared_recipe_id=shared_recipe_id)
-        highlight(("response:", response), "!")
+
         if not response:
             return
 
@@ -328,20 +328,16 @@ class RecipeServices():
     @staticmethod
     def share_recipe_standard_default_book(recipient, shared_recipe_id):
         """User shares recipe with Recipient that has STANDARD default book"""
-        # Nothing has to be done about setting the recipients default book
-        # retrieve shared_link(book)
-        # check if recipe has already been shared
-
-        # if not shared share recipe with recipients shared_book
         response = RecipeServices.fetch_shared_link(
             recipient_id=recipient.id, shared_recipe_id=shared_recipe_id)
 
         if not response:
-            return {"message": "Recipe already shared with user.",
-                    "error": "Conflict", "code": 409}
+            return 
 
-        RecipeBookRepo.create_entry(
-            book_id=response.book_id, recipe_id=shared_recipe_id)
+        message = RecipeServices.share_recipe(
+            share_inbox_id=response.book_id, recipe_id=shared_recipe_id, recipient_id=recipient.id)
+        
+        return message
 
     @staticmethod
     def share_recipe_shared_default_book(recipient, shared_recipe_id):

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -263,23 +263,28 @@ class RecipeServices():
         recipient = UserRepo.query_user_name(user_name=recipient)
         recipe = RecipeRepo.query_recipe(recipe_pk=recipe_id)
         recipe_build = RecipeServices.build_recipe(recipe_id=recipe_id)
-        # if not recipient:
-        #     return {"message": "User not found", "error": "Not Found", "code": 404}
-        # if auth_id == recipient.id:
-        #     return {"message": "Why are you sharing this with yourself???",
-        #             "error": "BadRequest", "code": 400}
-        # if not recipe.is_owned_by(auth_id):
-        #     return {"message": "This is not yours to share...",
-        #             "error": "Forbidden", "code": 403}
+
+        if not recipient:
+            return {"message": "User not found", "error": "Not Found", "code": 404}
+        if auth_id == recipient.id:
+            return {"message": "Why are you sharing this with yourself???",
+                    "error": "BadRequest", "code": 400}
+        if not recipe.is_owned_by(auth_id):
+            return {"message": "This is not yours to share...",
+                    "error": "Forbidden", "code": 403}
         try:
             message = RecipeServices.facilitate_recipe_link_creation(
                 recipient=recipient, shared_id=recipe_id)
+            
+            if not message:
+                return {"message": "Recipe already shared with user.",
+                    "error": "Conflict", "code": 409}
 
-            db.session.commit()
 
             message["recipient_id"] = recipient.id
 
             highlight(message, "!")
+            # db.session.commit()
             return {**message, "recipe": recipe_build}
         except Exception as e:
             db.session.rollback()
@@ -291,17 +296,17 @@ class RecipeServices():
         """"Distributes recipe data to corresponding function"""
 
         default_book_id = recipient.default_book_id
-        book_type = BookRepo.query_user_book_by_pk(default_book_id).book_type
+        book = BookRepo.query_user_book_by_pk(default_book_id)
 
         if not default_book_id:
             return RecipeServices.share_recipe_no_default_book(
-                recipient=recipient, shared_book_id=shared_id)
+                recipient=recipient, shared_recipe_id=shared_id)
 
-        if book_type == "standard":
+        if book.book_type == "standard":
             return RecipeServices.share_recipe_standard_default_book(
                 recipient=recipient, shared_book_id=shared_id)
 
-        if book_type == "shared_inbox":
+        if book.book_type == "shared_inbox":
             return RecipeServices.share_recipe_shared_default_book(
                 recipient=recipient, shared_book_id=shared_id)
 
@@ -311,8 +316,8 @@ class RecipeServices():
         response = RecipeServices.fetch_shared_link(
             recipient_id=recipient.id, shared_recipe_id=shared_recipe_id)
 
-        if response["error"]:
-            return response
+        if not response:
+            return 
 
         message = RecipeServices.share_recipe(
             book_id=response.book_id, recipe_id=shared_recipe_id, recipient_id=recipient.id)
@@ -333,8 +338,9 @@ class RecipeServices():
         response = RecipeServices.fetch_shared_link(
             recipient_id=recipient.id, shared_recipe_id=shared_recipe_id)
 
-        if response["error"]:
-            return response
+        if not response:
+            return {"message": "Recipe already shared with user.",
+                    "error": "Conflict", "code": 409}
 
         RecipeBookRepo.create_entry(
             book_id=response.book_id, recipe_id=shared_recipe_id)
@@ -357,10 +363,13 @@ class RecipeServices():
             shared_link = UserBookRepo.create_entry(
                 user_id=recipient_id, book_id=shared_book["id"])
 
-        response = RecipeBookRepo.does_recipe_exist_in_shared_inbox(
-            shared_link_id=shared_link.book_id, shared_book_id=shared_recipe_id)
+        is_recipe_shared = RecipeBookRepo.does_recipe_exist_in_shared_inbox(
+            shared_link_id=shared_link.book_id, shared_recipe_id=shared_recipe_id)
+        
+        highlight(is_recipe_shared == None, "!")
+        highlight(shared_link, "!")
 
-        return response if response else shared_link
+        return is_recipe_shared if not is_recipe_shared else shared_link
 
     @staticmethod
     def remove_recipe(auth_id, recipe_id, data):

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -15,7 +15,6 @@ class RecipeServices():
             notes = recipe.get("notes")
             instructions = recipe.get("instructions")
             ingredients = recipe.get("ingredients")
-            highlight(("recipe_data incoming",recipe, notes, instructions, ingredients),"!")
         except Exception as e:
             raise type(e)(
                 f"Failed to extract recipe data for book {book_id}: {e}") from e
@@ -37,7 +36,6 @@ class RecipeServices():
                 recipe_data["instructions"] = []
 
             db.session.commit()
-            highlight(("recipe_data:", recipe_data), "!")
             return recipe_data
         except Exception as e:
             db.session.rollback()
@@ -151,7 +149,6 @@ class RecipeServices():
     @staticmethod
     def process_edit(user_id, data, recipe_id):
         """Consolidates recipe edit process"""
-        highlight(("edit data:", data), "!")
         if user_id is not data.get("created_by_id"):
             raise Forbidden("Not authorized to make edits")
         try:
@@ -278,7 +275,6 @@ class RecipeServices():
                 return {"message": "Recipe already shared with user.",
                         "error": "Conflict", "code": 409}
 
-            highlight(message, "!")
             db.session.commit()
             return {**message, "recipe": recipe_build}
         except Exception as e:
@@ -358,9 +354,6 @@ class RecipeServices():
 
         is_recipe_shared = RecipeBookRepo.does_recipe_exist_in_shared_inbox(
             shared_link_id=shared_link.book_id, shared_recipe_id=shared_recipe_id)
-
-        highlight(("is_recipe_shared:", is_recipe_shared), "!")
-        highlight(("shared_link:", shared_link), "!")
 
         return is_recipe_shared or shared_link
 

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -247,8 +247,7 @@ class RecipeServices():
                         recipe_id=recipe_id, instruction_id=instruction["newId"])
 
                     if not recipe_instruction:
-                        raise NotFound(
-                            "No recipe instruction associated not found")
+                        
                 else:
                     RecipeInstructionRepo.create_entry(
                         recipe_id=recipe_id,

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -87,7 +87,7 @@ class RecipeServices():
         """Processes consolidated instructions and associates each instruction to Recipe"""
         try:
             instructions_data = InstructionServices.process_instructions(
-                instructions=instructions, book_id=book_id)
+                instructions=instructions, recipe_id=recipe_id)
 
             if not instructions_data:
                 raise ValueError(

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -274,6 +274,7 @@ class RecipeServices():
                 recipient=recipient, shared_id=recipe_id)
             db.session.commit()
             message["recipient_id"] = recipient.id
+            highlight(message,"!")
             return {**message, "recipe": recipe_build}
         except Exception as e:
             db.session.rollback()

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -275,16 +275,14 @@ class RecipeServices():
         try:
             message = RecipeServices.facilitate_recipe_link_creation(
                 recipient=recipient, shared_id=recipe_id)
-            
+
             if not message:
+                db.session.rollback()
                 return {"message": "Recipe already shared with user.",
-                    "error": "Conflict", "code": 409}
-
-
-            message["recipient_id"] = recipient.id
+                        "error": "Conflict", "code": 409}
 
             highlight(message, "!")
-            # db.session.commit()
+            db.session.commit()
             return {**message, "recipe": recipe_build}
         except Exception as e:
             db.session.rollback()
@@ -315,12 +313,12 @@ class RecipeServices():
         """User shares recipe with Recipient that has no default book assigned"""
         response = RecipeServices.fetch_shared_link(
             recipient_id=recipient.id, shared_recipe_id=shared_recipe_id)
-
+        highlight(("response:", response), "!")
         if not response:
-            return 
+            return
 
         message = RecipeServices.share_recipe(
-            book_id=response.book_id, recipe_id=shared_recipe_id, recipient_id=recipient.id)
+            share_inbox_id=response.book_id, recipe_id=shared_recipe_id, recipient_id=recipient.id)
 
         # Assign Shared Recipe as default book
         recipient.default_book_id = response.book_id
@@ -365,11 +363,11 @@ class RecipeServices():
 
         is_recipe_shared = RecipeBookRepo.does_recipe_exist_in_shared_inbox(
             shared_link_id=shared_link.book_id, shared_recipe_id=shared_recipe_id)
-        
-        highlight(is_recipe_shared == None, "!")
-        highlight(shared_link, "!")
 
-        return is_recipe_shared if not is_recipe_shared else shared_link
+        highlight(("is_recipe_shared:", is_recipe_shared), "!")
+        highlight(("shared_link:", shared_link), "!")
+
+        return is_recipe_shared or shared_link
 
     @staticmethod
     def remove_recipe(auth_id, recipe_id, data):
@@ -411,9 +409,13 @@ class RecipeServices():
     def share_recipe(share_inbox_id, recipe_id, recipient_id):
         """Associate user's shared recipe to recipients 'Shared Recipes' book"""
         # take a look at this return object
-        RecipeBookRepo.create_entry(book_id=share_inbox_id, recipe_id=recipe_id)
+        RecipeBookRepo.create_entry(
+            book_id=share_inbox_id, recipe_id=recipe_id)
 
         book_with_role = BookRepo.build_book(
             user_id=recipient_id, book_id=share_inbox_id)
 
-        return {"message": "Recipe successfully shared!", "code": 200, "payload": book_with_role}
+        return {"message": "Recipe successfully shared!", 
+                "recipient_id": recipe_id,
+                 "code": 200, "payload": book_with_role
+                 }

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -261,16 +261,16 @@ class RecipeServices():
         recipient = UserRepo.query_user_name(user_name=recipient)
         recipe = RecipeRepo.query_recipe(recipe_pk=recipe_id)
         recipe_build = RecipeServices.build_recipe(recipe_id=recipe_id)
-        if not recipient:
-            return {"message": "User not found", "error": "Not Found", "code": 404}
-        if auth_id == recipient.id:
-            return {"message": "Why are you sharing this with yourself???", 
-                    "error": "BadRequest", "code": 400}
-        if not recipe.is_owned_by(auth_id):
-            return {"message": "This is not yours to share...",
-                    "error": "Forbidden", "code": 403}
+        # if not recipient:
+        #     return {"message": "User not found", "error": "Not Found", "code": 404}
+        # if auth_id == recipient.id:
+        #     return {"message": "Why are you sharing this with yourself???", 
+        #             "error": "BadRequest", "code": 400}
+        # if not recipe.is_owned_by(auth_id):
+        #     return {"message": "This is not yours to share...",
+        #             "error": "Forbidden", "code": 403}
         try:
-            RecipeServices.facilitate_recipe_link_creation()
+            RecipeServices.facilitate_recipe_link_creation(recipient=recipient,shared_id=recipe_id)
             return
             message = RecipeRepo.create_recipe_link(
                 recipient=recipient, shared_id=recipe_id)
@@ -288,19 +288,19 @@ class RecipeServices():
         """"Distributes recipe data to corresponding function"""
         book = None
 
-        default_book = recipient.default_book_id
+        default_book_id = recipient.default_book_id
+        book_type = BookRepo.query_user_book_by_pk(default_book_id)
 
-        book_type = BookRepo.query_user_book_by_pk()
-
-        # shared_book = UserBookRepo.query_shared_book(recipient_id=recipient.id)
-
-        # Choose corresponding function
-        if not default_book:
+        if not default_book_id:
             RecipeServices.share_recipe_no_default_book()
 
-        # if recipient has STANDARD book - check query book -> book.book_type
+        if book_type == "standard":
+            RecipeServices.share_recipe_standard_default_book()
 
+        if book_type == "shared_inbox":
+            RecipeServices.share_recipe_shared_default_book()
 
+    
 
 
     @staticmethod

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -328,12 +328,27 @@ class RecipeServices():
         return {"message": "Recipe successfully shared!", "code": 200, "payload": book_with_role}
 
     @staticmethod
-    def share_recipe_standard_default_book():
+    def share_recipe_standard_default_book(recipient, shared_recipe_id):
         """User shares recipe with Recipient that has STANDARD default book"""
+        # Nothing has to be done about setting the recipients default book
+        # retrieve shared_link(book)
+        # check if recipe has already been shared
+
+        # if not shared shared recipe with recipients shared_book
+        response = RecipeServices.fetch_shared_link(
+            recipient_id=recipient.id, shared_recipe_id=shared_recipe_id)
+        
+        if response ["error"]:
+            return response
+        
+        RecipeBookRepo.create_entry(
+            book_id=response.book_id, recipe_id=shared_recipe_id)
 
     @staticmethod
-    def share_recipe_shared_default_book():
+    def share_recipe_shared_default_book(recipient, shared_recipe_id):
         """User shares recipe with Recipient that has SHARED default book"""
+        response = RecipeServices.fetch_shared_link(
+            recipient_id=recipient.id, shared_recipe_id=shared_recipe_id)
 
     @staticmethod
     def fetch_shared_link(recipient_id, shared_recipe_id):

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -240,14 +240,21 @@ class RecipeServices():
         """Edits recipe's instructions by - either modifying existing 
         instruction or creating a new one"""
         highlight(("instructions:", instructions), "!")
+        #check if instruction needs to be replaced or created
+        # replaced if there is an old id
+        # created if there is no old id
+        # replace instruction 
+            # I need the instruction association and replace instruction id
+        # create addition instruction
+            # simply create new association 
         try:
             for instruction in instructions:
                 if instruction["oldId"]:
-                    recipe_instruction = RecipeInstructionRepo.query_recipe_instruction(
+                    instance = RecipeInstructionRepo.query_recipe_instruction(
                         recipe_id=recipe_id, instruction_id=instruction["newId"])
+                    
+                    instance.instruction_id = instruction["newId"]
 
-                    if not recipe_instruction:
-                        
                 else:
                     RecipeInstructionRepo.create_entry(
                         recipe_id=recipe_id,

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -272,13 +272,13 @@ class RecipeServices():
         #     return {"message": "This is not yours to share...",
         #             "error": "Forbidden", "code": 403}
         try:
-            RecipeServices.facilitate_recipe_link_creation(
+            message = RecipeServices.facilitate_recipe_link_creation(
                 recipient=recipient, shared_id=recipe_id)
 
-            message = RecipeRepo.create_recipe_link(
-                recipient=recipient, shared_id=recipe_id)
             db.session.commit()
+
             message["recipient_id"] = recipient.id
+
             highlight(message, "!")
             return {**message, "recipe": recipe_build}
         except Exception as e:
@@ -294,17 +294,38 @@ class RecipeServices():
         book_type = BookRepo.query_user_book_by_pk(default_book_id).book_type
 
         if not default_book_id:
-            RecipeServices.share_recipe_no_default_book()
+            return RecipeServices.share_recipe_no_default_book(
+                recipient=recipient, shared_book_id=shared_id)
 
         if book_type == "standard":
-            RecipeServices.share_recipe_standard_default_book()
+            return RecipeServices.share_recipe_standard_default_book(
+                recipient=recipient, shared_book_id=shared_id)
 
         if book_type == "shared_inbox":
-            RecipeServices.share_recipe_shared_default_book()
+            return RecipeServices.share_recipe_shared_default_book(
+                recipient=recipient, shared_book_id=shared_id)
 
     @staticmethod
-    def share_recipe_no_default_book():
+    def share_recipe_no_default_book(recipient, shared_recipe_id):
         """User shares recipe with Recipient that has no default book assigned"""
+        response = RecipeServices.fetch_shared_link(
+            recipient_id=recipient.id, shared_recipe_id=shared_recipe_id)
+
+        if response["error"]:
+            return response
+
+        # share recipe with recipient's Shared Recipes book
+        RecipeBookRepo.create_entry(
+            book_id=response.book_id, recipe_id=shared_recipe_id)
+
+        # Assign Shared Recipe as default book
+        recipient.default_book_id = response.book_id
+
+        # Build return object for client
+        book_with_role = BookRepo.build_book(
+            user_id=recipient.id, book_id=response.book_id)
+
+        return {"message": "Recipe successfully shared!", "code": 200, "payload": book_with_role}
 
     @staticmethod
     def share_recipe_standard_default_book():
@@ -315,27 +336,21 @@ class RecipeServices():
         """User shares recipe with Recipient that has SHARED default book"""
 
     @staticmethod
-    def fetch_shared_link(recipient_id, shared_id):
+    def fetch_shared_link(recipient_id, shared_recipe_id):
         """Queries shared link. Create if necessary and return link if not already shared"""
-        try:
-            shared_link = UserBookRepo.query_shared_book(
-                recipient_id=recipient_id)
+        shared_link = UserBookRepo.query_shared_book(recipient_id=recipient_id)
 
-            if not shared_link:
-                shared_book = BookRepo.create_book(title="Shared Recipes",
-                                                   description="Inbox: Recipes shared by others",
-                                                   book_type=BookType.shared_inbox)
-                shared_link = UserBookRepo.create_entry(
-                    user_id=recipient_id, book_id=shared_book["id"])
+        if not shared_link:
+            shared_book = BookRepo.create_book(title="Shared Recipes",
+                                               description="Inbox: Recipes shared by others",
+                                               book_type=BookType.shared_inbox)
+            shared_link = UserBookRepo.create_entry(
+                user_id=recipient_id, book_id=shared_book["id"])
 
-            response = RecipeBookRepo.does_recipe_exist_in_shared_inbox(
-                shared_link_id=shared_link.book_id, shared_book_id=shared_id)
+        response = RecipeBookRepo.does_recipe_exist_in_shared_inbox(
+            shared_link_id=shared_link.book_id, shared_book_id=shared_recipe_id)
 
-            return response if response else shared_link
-
-        except Exception as e:
-            db.session.rollback()
-            raise
+        return response if response else shared_link
 
     @staticmethod
     def remove_recipe(auth_id, recipe_id, data):

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -95,6 +95,7 @@ class RecipeServices():
             for instruction in instructions_data:
                 id = RecipeInstructionRepo.create_entry(
                     recipe_id=recipe_id, instruction_id=instruction["id"])
+                
                 instruction["instruction_id"] = id
 
             return instructions_data

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -237,25 +237,17 @@ class RecipeServices():
 
     @staticmethod
     def process_edit_instructions(instructions, recipe_id):
-        """Edits recipe's instructions by - either modifying existing 
-        instruction or creating a new one"""
-        highlight(("instructions:", instructions), "!")
-        #check if instruction needs to be replaced or created
-        # replaced if there is an old id
-        # created if there is no old id
-        # replace instruction 
-            # I need the instruction association and replace instruction id
-        # create addition instruction
-            # simply create new association 
+        """Edits recipe's instructions - modifying existing instruction or 
+        creating a new one"""
         try:
             for instruction in instructions:
                 if instruction["oldId"]:
                     instance = RecipeInstructionRepo.query_recipe_instruction(
-                        recipe_id=recipe_id, instruction_id=instruction["newId"])
+                        recipe_id=recipe_id, instruction_id=instruction["oldId"])
                     
                     instance.instruction_id = instruction["newId"]
 
-                else:
+                if instruction["oldId"] is None:
                     RecipeInstructionRepo.create_entry(
                         recipe_id=recipe_id,
                         instruction_id=instruction["newId"])

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -270,6 +270,8 @@ class RecipeServices():
             return {"message": "This is not yours to share...",
                     "error": "Forbidden", "code": 403}
         try:
+            RecipeServices.facilitate_recipe_link_creation()
+            return
             message = RecipeRepo.create_recipe_link(
                 recipient=recipient, shared_id=recipe_id)
             db.session.commit()
@@ -281,14 +283,25 @@ class RecipeServices():
             raise type(e)(
                 f"Failed to share_recipe error: {e}") from e
         
-    
     @staticmethod
-    def share_book_no_default_book():
-        """User shares Book with Recipient that has no default book assigned"""
+    def facilitate_recipe_link_creation(recipient, shared_id):
+        """"Distributes recipe data to corresponding function"""
+        book = None
 
-    @staticmethod
-    def share_book_has_default_book():
-        """User shares with Recipient that has assigned default book"""
+        default_book = recipient.default_book_id
+
+        book_type = BookRepo.query_user_book_by_pk()
+
+        # shared_book = UserBookRepo.query_shared_book(recipient_id=recipient.id)
+
+        # Choose corresponding function
+        if not default_book:
+            RecipeServices.share_recipe_no_default_book()
+
+        # if recipient has STANDARD book - check query book -> book.book_type
+
+
+
 
     @staticmethod
     def share_recipe_no_default_book():

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -130,26 +130,28 @@ class RecipeServices():
             return complete_recipes
         except Exception as e:
             raise type(e)(f"RecipeServices - build_recipes error: {e}") from e
-    
-    @staticmethod 
+
+    @staticmethod
     def build_recipe(recipe_id):
         """Builds individual recipes"""
         try:
             recipe = RecipeRepo.query_recipe(recipe_pk=recipe_id)
-            instructions = InstructionServices.build_instructions(instances=recipe.instructions, recipe_id=recipe_id)
-            ingredients = IngredientServices.build_ingredients(instance=recipe.ingredients)
+            instructions = InstructionServices.build_instructions(
+                instances=recipe.instructions, recipe_id=recipe_id)
+            ingredients = IngredientServices.build_ingredients(
+                instance=recipe.ingredients)
             return {
-                    "is_owned_by": recipe.created_by_id,
-                    "id":recipe.id, 
-                    "created_by_id":recipe.created_by_id, 
-                    "name": recipe.name,
-                    "ingredients": ingredients,
-                    "instructions": instructions,
-                    "notes": recipe.notes
-                    }
+                "is_owned_by": recipe.created_by_id,
+                "id": recipe.id,
+                "created_by_id": recipe.created_by_id,
+                "name": recipe.name,
+                "ingredients": ingredients,
+                "instructions": instructions,
+                "notes": recipe.notes
+            }
         except Exception as e:
             raise type(e)(f"RecipeServices - build_recipe error: {e}") from e
-        
+
     @staticmethod
     def process_edit(user_id, data, recipe_id):
         """Consolidates recipe edit process"""
@@ -264,32 +266,32 @@ class RecipeServices():
         # if not recipient:
         #     return {"message": "User not found", "error": "Not Found", "code": 404}
         # if auth_id == recipient.id:
-        #     return {"message": "Why are you sharing this with yourself???", 
+        #     return {"message": "Why are you sharing this with yourself???",
         #             "error": "BadRequest", "code": 400}
         # if not recipe.is_owned_by(auth_id):
         #     return {"message": "This is not yours to share...",
         #             "error": "Forbidden", "code": 403}
         try:
-            RecipeServices.facilitate_recipe_link_creation(recipient=recipient,shared_id=recipe_id)
-            return
+            RecipeServices.facilitate_recipe_link_creation(
+                recipient=recipient, shared_id=recipe_id)
+
             message = RecipeRepo.create_recipe_link(
                 recipient=recipient, shared_id=recipe_id)
             db.session.commit()
             message["recipient_id"] = recipient.id
-            highlight(message,"!")
+            highlight(message, "!")
             return {**message, "recipe": recipe_build}
         except Exception as e:
             db.session.rollback()
             raise type(e)(
                 f"Failed to share_recipe error: {e}") from e
-        
+
     @staticmethod
     def facilitate_recipe_link_creation(recipient, shared_id):
         """"Distributes recipe data to corresponding function"""
-        book = None
 
         default_book_id = recipient.default_book_id
-        book_type = BookRepo.query_user_book_by_pk(default_book_id)
+        book_type = BookRepo.query_user_book_by_pk(default_book_id).book_type
 
         if not default_book_id:
             RecipeServices.share_recipe_no_default_book()
@@ -299,9 +301,6 @@ class RecipeServices():
 
         if book_type == "shared_inbox":
             RecipeServices.share_recipe_shared_default_book()
-
-    
-
 
     @staticmethod
     def share_recipe_no_default_book():
@@ -314,6 +313,31 @@ class RecipeServices():
     @staticmethod
     def share_recipe_shared_default_book():
         """User shares recipe with Recipient that has SHARED default book"""
+
+    @staticmethod
+    def fetch_shared_link(recipient_id, shared_id):
+        """Queries shared link. If none, shared link is created. Returns link"""
+        try:
+            shared_link = UserBookRepo.query_shared_book(
+                recipient_id=recipient_id)
+
+            if not shared_link:
+                shared_book = BookRepo.create_book(title="Shared Recipes",
+                                                   description="Inbox: Recipes shared by others",
+                                                   book_type=BookType.shared_inbox)
+                shared_link = UserBookRepo.create_entry(
+                    user_id=recipient_id, book_id=shared_book["id"])
+
+                response = RecipeBookRepo.does_recipe_exist_in_shared_inbox(
+                    shared_link_id=shared_link.book_id, shared_book_id=shared_id)
+                
+                if response:
+                    return response
+
+            return shared_link
+        except Exception as e:
+            db.session.rollback()
+            raise
 
     @staticmethod
     def remove_recipe(auth_id, recipe_id, data):
@@ -332,16 +356,18 @@ class RecipeServices():
     @staticmethod
     def remove_shared_recipe(authed_id, recipe_id, book_id):
         """Verifies shared recipe belongs to user's shared book. Then deletes association"""
-        user_book = UserBookRepo.query_user_book(book_id=book_id, user_id=authed_id)
-        highlight(user_book,"!")
+        user_book = UserBookRepo.query_user_book(
+            book_id=book_id, user_id=authed_id)
+        highlight(user_book, "!")
         if not user_book:
-                raise NotFound("Not found")
-        is_book_type_shared = user_book.book.book_type 
-        if not is_book_type_shared: 
+            raise NotFound("Not found")
+        is_book_type_shared = user_book.book.book_type
+        if not is_book_type_shared:
             raise ForbiddenError("Forbidden request")
         try:
-            highlight((book_id,recipe_id),"!")
-            response = RecipeBookRepo.remove_book_association(book_id=book_id,recipe_id=recipe_id)
+            highlight((book_id, recipe_id), "!")
+            response = RecipeBookRepo.remove_book_association(
+                book_id=book_id, recipe_id=recipe_id)
             db.session.commit()
             return response
         except Exception as e:

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -36,7 +36,7 @@ class RecipeServices():
                 recipe_data["instructions"] = []
 
             db.session.commit()
-
+            highlight(("recipe_data:",recipe_data),"!")
             return recipe_data
         except Exception as e:
             db.session.rollback()
@@ -95,8 +95,9 @@ class RecipeServices():
             for instruction in instructions_data:
                 id = RecipeInstructionRepo.create_entry(
                     recipe_id=recipe_id, instruction_id=instruction["id"])
-                
+                highlight(("instruction:",instruction, "id:",id),"!")
                 instruction["instruction_id"] = id
+                highlight(("instruction:",instruction, "id:",id),"!")
 
             return instructions_data
         except Exception as e:
@@ -156,6 +157,7 @@ class RecipeServices():
     @staticmethod
     def process_edit(user_id, data, recipe_id):
         """Consolidates recipe edit process"""
+        highlight(("edit data:",data),"!")
         if user_id is not data.get("created_by_id"):
             raise Forbidden("Not authorized to make edits")
         try:
@@ -242,6 +244,7 @@ class RecipeServices():
     @staticmethod
     def process_edit_instructions(instructions, recipe_id):
         """Edits recipe's instructions by modifying RecipeInstruction association"""
+        highlight(("instructions:", instructions), "!")
         try:
             for instruction in instructions:
                 if instruction["associationId"]:

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -299,14 +299,17 @@ class RecipeServices():
         if not default_book_id:
             return RecipeServices.share_recipe_no_default_book(
                 recipient=recipient, shared_recipe_id=shared_id)
-
-        if book.book_type == "standard":
+        
+        if book.book_type.value == "standard":
             return RecipeServices.share_recipe_standard_default_book(
-                recipient=recipient, shared_book_id=shared_id)
+                recipient=recipient, shared_recipe_id=shared_id)
 
-        if book.book_type == "shared_inbox":
+        if book.book_type.value == "shared_inbox":
             return RecipeServices.share_recipe_shared_default_book(
                 recipient=recipient, shared_book_id=shared_id)
+
+        return {"message": "Nothing to process - try your request again.",
+                "error": "Unknown", "code": 500}
 
     @staticmethod
     def share_recipe_no_default_book(recipient, shared_recipe_id):
@@ -332,11 +335,11 @@ class RecipeServices():
             recipient_id=recipient.id, shared_recipe_id=shared_recipe_id)
 
         if not response:
-            return 
+            return
 
         message = RecipeServices.share_recipe(
             share_inbox_id=response.book_id, recipe_id=shared_recipe_id, recipient_id=recipient.id)
-        
+
         return message
 
     @staticmethod
@@ -349,7 +352,6 @@ class RecipeServices():
     def fetch_shared_link(recipient_id, shared_recipe_id):
         """Queries shared link. Create if necessary and return link if not already shared"""
         shared_link = UserBookRepo.query_shared_book(recipient_id=recipient_id)
-
         if not shared_link:
             shared_book = BookRepo.create_book(title="Shared Recipes",
                                                description="Inbox: Recipes shared by others",
@@ -405,13 +407,13 @@ class RecipeServices():
     def share_recipe(share_inbox_id, recipe_id, recipient_id):
         """Associate user's shared recipe to recipients 'Shared Recipes' book"""
         # take a look at this return object
-        RecipeBookRepo.create_entry(
+        res = RecipeBookRepo.create_entry(
             book_id=share_inbox_id, recipe_id=recipe_id)
-
+        highlight(("RES:", res), "!")
         book_with_role = BookRepo.build_book(
             user_id=recipient_id, book_id=share_inbox_id)
 
-        return {"message": "Recipe successfully shared!", 
+        return {"message": "Recipe successfully shared!",
                 "recipient_id": recipe_id,
-                 "code": 200, "payload": book_with_role
-                 }
+                "code": 200, "payload": book_with_role
+                }

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -280,6 +280,27 @@ class RecipeServices():
             db.session.rollback()
             raise type(e)(
                 f"Failed to share_recipe error: {e}") from e
+        
+    
+    @staticmethod
+    def share_book_no_default_book():
+        """User shares Book with Recipient that has no default book assigned"""
+
+    @staticmethod
+    def share_book_has_default_book():
+        """User shares with Recipient that has assigned default book"""
+
+    @staticmethod
+    def share_recipe_no_default_book():
+        """User shares recipe with Recipient that has no default book assigned"""
+
+    @staticmethod
+    def share_recipe_standard_default_book():
+        """User shares recipe with Recipient that has STANDARD default book"""
+
+    @staticmethod
+    def share_recipe_shared_default_book():
+        """User shares recipe with Recipient that has SHARED default book"""
 
     @staticmethod
     def remove_recipe(auth_id, recipe_id, data):

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -59,7 +59,7 @@ class RecipeServices():
 
     @staticmethod
     def process_ingredients(ingredients, recipe_id, book_id):
-        """Processes ingredient components effectively creating an ingredient and associates each ingredient to recipe"""
+        """Processes ingredient components creating an ingredient and associates each ingredient to recipe"""
         try:
             ingredients_data = IngredientServices.process_ingredient_components(
                 book_id=book_id, ingredients=ingredients)
@@ -271,7 +271,7 @@ class RecipeServices():
                     "error": "Forbidden", "code": 403}
         try:
             message = RecipeRepo.create_recipe_link(
-                recipient_id=recipient.id, shared_id=recipe_id)
+                recipient=recipient, shared_id=recipe_id)
             db.session.commit()
             message["recipient_id"] = recipient.id
             return {**message, "recipe": recipe_build}

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -15,6 +15,7 @@ class RecipeServices():
             notes = recipe.get("notes")
             instructions = recipe.get("instructions")
             ingredients = recipe.get("ingredients")
+            highlight(("recipe_data incoming",recipe, notes, instructions, ingredients),"!")
         except Exception as e:
             raise type(e)(
                 f"Failed to extract recipe data for book {book_id}: {e}") from e

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -36,7 +36,7 @@ class RecipeServices():
                 recipe_data["instructions"] = []
 
             db.session.commit()
-            highlight(("recipe_data:",recipe_data),"!")
+            highlight(("recipe_data:", recipe_data), "!")
             return recipe_data
         except Exception as e:
             db.session.rollback()
@@ -92,13 +92,6 @@ class RecipeServices():
                 raise ValueError(
                     f"No instructions data returned for book id: {book_id}")
 
-            for instruction in instructions_data:
-                id = RecipeInstructionRepo.create_entry(
-                    recipe_id=recipe_id, instruction_id=instruction["id"])
-                highlight(("instruction:",instruction, "id:",id),"!")
-                instruction["instruction_id"] = id
-                highlight(("instruction:",instruction, "id:",id),"!")
-
             return instructions_data
         except Exception as e:
             raise type(e)(
@@ -121,7 +114,7 @@ class RecipeServices():
                 recipe_build.update(recipe)
 
                 instructions = InstructionServices.build_instructions(
-                    instances=recipe_instance.instructions, recipe_id=recipe["id"])
+                    instances=recipe_instance.instructions)
                 recipe_build["instructions"] = instructions
 
                 ingredients = IngredientServices.build_ingredients(
@@ -139,7 +132,7 @@ class RecipeServices():
         try:
             recipe = RecipeRepo.query_recipe(recipe_pk=recipe_id)
             instructions = InstructionServices.build_instructions(
-                instances=recipe.instructions, recipe_id=recipe_id)
+                instances=recipe.instructions)
             ingredients = IngredientServices.build_ingredients(
                 instance=recipe.ingredients)
             return {
@@ -157,7 +150,7 @@ class RecipeServices():
     @staticmethod
     def process_edit(user_id, data, recipe_id):
         """Consolidates recipe edit process"""
-        highlight(("edit data:",data),"!")
+        highlight(("edit data:", data), "!")
         if user_id is not data.get("created_by_id"):
             raise Forbidden("Not authorized to make edits")
         try:
@@ -243,17 +236,18 @@ class RecipeServices():
 
     @staticmethod
     def process_edit_instructions(instructions, recipe_id):
-        """Edits recipe's instructions by modifying RecipeInstruction association"""
+        """Edits recipe's instructions by - either modifying existing 
+        instruction or creating a new one"""
         highlight(("instructions:", instructions), "!")
         try:
             for instruction in instructions:
-                if instruction["associationId"]:
-                    recipe_instruction = RecipeInstruction.query.get(
-                        instruction["associationId"])
+                if instruction["oldId"]:
+                    recipe_instruction = RecipeInstructionRepo.query_recipe_instruction(
+                        recipe_id=recipe_id, instruction_id=instruction["newId"])
+
                     if not recipe_instruction:
                         raise NotFound(
-                            f"No recipe_instruction associated to id # {instruction['associationId']}")
-                    recipe_instruction.instruction_id = instruction["newId"]
+                            "No recipe instruction associated not found")
                 else:
                     RecipeInstructionRepo.create_entry(
                         recipe_id=recipe_id,
@@ -303,7 +297,7 @@ class RecipeServices():
         if not default_book_id:
             return RecipeServices.share_recipe_no_default_book(
                 recipient=recipient, shared_recipe_id=shared_id)
-        
+
         if book.book_type.value == "standard":
             return RecipeServices.share_recipe_standard_default_book(
                 recipient=recipient, shared_recipe_id=shared_id)

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -258,7 +258,7 @@ class RecipeServices():
             raise type(e)(f"Failed to process_edit_instructions: {e}") from e
 
     @staticmethod
-    def share_recipe(auth_id, recipient, recipe_id):
+    def process_recipe_share(auth_id, recipient, recipe_id):
         """Process sharing user recipe with recipient"""
         recipient = UserRepo.query_user_name(user_name=recipient)
         recipe = RecipeRepo.query_recipe(recipe_pk=recipe_id)
@@ -284,7 +284,7 @@ class RecipeServices():
         except Exception as e:
             db.session.rollback()
             raise type(e)(
-                f"Failed to share_recipe error: {e}") from e
+                f"Failed to process_recipe_share error: {e}") from e
 
     @staticmethod
     def facilitate_recipe_link_creation(recipient, shared_id):
@@ -314,18 +314,13 @@ class RecipeServices():
         if response["error"]:
             return response
 
-        # share recipe with recipient's Shared Recipes book
-        RecipeBookRepo.create_entry(
-            book_id=response.book_id, recipe_id=shared_recipe_id)
+        message = RecipeServices.share_recipe(
+            book_id=response.book_id, recipe_id=shared_recipe_id, recipient_id=recipient.id)
 
         # Assign Shared Recipe as default book
         recipient.default_book_id = response.book_id
 
-        # Build return object for client
-        book_with_role = BookRepo.build_book(
-            user_id=recipient.id, book_id=response.book_id)
-
-        return {"message": "Recipe successfully shared!", "code": 200, "payload": book_with_role}
+        return message
 
     @staticmethod
     def share_recipe_standard_default_book(recipient, shared_recipe_id):
@@ -334,13 +329,13 @@ class RecipeServices():
         # retrieve shared_link(book)
         # check if recipe has already been shared
 
-        # if not shared shared recipe with recipients shared_book
+        # if not shared share recipe with recipients shared_book
         response = RecipeServices.fetch_shared_link(
             recipient_id=recipient.id, shared_recipe_id=shared_recipe_id)
-        
-        if response ["error"]:
+
+        if response["error"]:
             return response
-        
+
         RecipeBookRepo.create_entry(
             book_id=response.book_id, recipe_id=shared_recipe_id)
 
@@ -386,14 +381,15 @@ class RecipeServices():
         """Verifies shared recipe belongs to user's shared book. Then deletes association"""
         user_book = UserBookRepo.query_user_book(
             book_id=book_id, user_id=authed_id)
-        highlight(user_book, "!")
+
         if not user_book:
             raise NotFound("Not found")
         is_book_type_shared = user_book.book.book_type
+
         if not is_book_type_shared:
             raise ForbiddenError("Forbidden request")
+
         try:
-            highlight((book_id, recipe_id), "!")
             response = RecipeBookRepo.remove_book_association(
                 book_id=book_id, recipe_id=recipe_id)
             db.session.commit()
@@ -401,3 +397,14 @@ class RecipeServices():
         except Exception as e:
             db.session.rollback()
             raise type(e)(f"Failed to remove_shared_recipe error: {e}") from e
+
+    @staticmethod
+    def share_recipe(share_inbox_id, recipe_id, recipient_id):
+        """Associate user's shared recipe to recipients 'Shared Recipes' book"""
+        # take a look at this return object
+        RecipeBookRepo.create_entry(book_id=share_inbox_id, recipe_id=recipe_id)
+
+        book_with_role = BookRepo.build_book(
+            user_id=recipient_id, book_id=share_inbox_id)
+
+        return {"message": "Recipe successfully shared!", "code": 200, "payload": book_with_role}

--- a/services/recipes_services.py
+++ b/services/recipes_services.py
@@ -316,7 +316,7 @@ class RecipeServices():
 
     @staticmethod
     def fetch_shared_link(recipient_id, shared_id):
-        """Queries shared link. If none, shared link is created. Returns link"""
+        """Queries shared link. Create if necessary and return link if not already shared"""
         try:
             shared_link = UserBookRepo.query_shared_book(
                 recipient_id=recipient_id)
@@ -328,13 +328,11 @@ class RecipeServices():
                 shared_link = UserBookRepo.create_entry(
                     user_id=recipient_id, book_id=shared_book["id"])
 
-                response = RecipeBookRepo.does_recipe_exist_in_shared_inbox(
-                    shared_link_id=shared_link.book_id, shared_book_id=shared_id)
-                
-                if response:
-                    return response
+            response = RecipeBookRepo.does_recipe_exist_in_shared_inbox(
+                shared_link_id=shared_link.book_id, shared_book_id=shared_id)
 
-            return shared_link
+            return response if response else shared_link
+
         except Exception as e:
             db.session.rollback()
             raise

--- a/services/user_services.py
+++ b/services/user_services.py
@@ -15,6 +15,7 @@ class UserServices():
         last_name = request.json["lastName"]
         password = request.json["password"]
         email = request.json["email"]
+        highlight(request.json,"!")
         try:
             token = UserRepo.signup(user_name, first_name,
                                     last_name, email, password)

--- a/services/user_services.py
+++ b/services/user_services.py
@@ -85,6 +85,7 @@ class UserServices():
             user = User.query.get(user_id)
             if user.default_book_id is None:
                 user.default_book_id = book_id
+                return True
                 # db.session.add() is unnecessary if self is already a tracked/persistent object
         except Exception as e:
             db.session.rollback()

--- a/services/user_services.py
+++ b/services/user_services.py
@@ -15,7 +15,6 @@ class UserServices():
         last_name = request.json["lastName"]
         password = request.json["password"]
         email = request.json["email"]
-        highlight(request.json,"!")
         try:
             token = UserRepo.signup(user_name, first_name,
                                     last_name, email, password)


### PR DESCRIPTION
Originally meant to contain all code additions that handled the change of ownership of a recipe. What first seemed like a few isolated PRs dedicated to patching up some technical debt associated to the RecipeInstruction model and other association table and turned into a total refactor of those table and their association pipeline/ functions. Hence the name change. Note: branch name was not changed. 

DISREGARD NOTES BELOW

Creating pipeline to allow client request so a user can:
1. copy a recipe from one book to another - this creates an entirely new recipe for the user. CURD capabilities enabled.
2. move a recipe from one book to another - this allows the user to **view** the original recipe in other books. CRUD disabled.